### PR TITLE
Remove stale MUMPS library link directives from rmumps/build.rs

### DIFF
--- a/rmumps/build.rs
+++ b/rmumps/build.rs
@@ -1,14 +1,1 @@
-fn main() {
-    // Link the MUMPS C wrapper and MUMPS libraries for benchmarks
-    println!("cargo:rustc-link-search=native=/tmp");
-    println!("cargo:rustc-link-lib=static=mumps_wrapper");
-
-    println!("cargo:rustc-link-search=native=/opt/homebrew/Cellar/ipopt/3.14.19/lib");
-    println!("cargo:rustc-link-lib=dylib=dmumps");
-    println!("cargo:rustc-link-lib=dylib=mumps_common");
-    println!("cargo:rustc-link-lib=dylib=mpiseq");
-    println!("cargo:rustc-link-lib=dylib=pord");
-
-    println!("cargo:rustc-link-search=native=/opt/homebrew/opt/gcc/lib/gcc/current");
-    println!("cargo:rustc-link-lib=dylib=gfortran");
-}
+fn main() {}


### PR DESCRIPTION
rmumps is a pure Rust reimplementation and has no external library
dependencies. The build.rs was leftover from earlier experimentation
against real MUMPS libraries, hardcoding paths to /tmp and Homebrew
that only exist on the original developer's machine, causing build
failures everywhere else.

https://claude.ai/code/session_01HZoGUsyD2xofUiJnQ6jt34