### PR TITLE
feat(nl): parse + evaluate AMPL external functions (#15)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -674,6 +674,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6800badb6cb2082ffd7b6a67e6125bb39f18782f793520caee8cb8846be06112"
 
 [[package]]
+name = "libloading"
+version = "0.8.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d7c4b02199fee7c5d21a5ae7d8cfa79a6ef5bb2fc834d6e9058e89c825efdc55"
+dependencies = [
+ "cfg-if",
+ "windows-link",
+]
+
+[[package]]
 name = "libm"
 version = "0.2.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1243,6 +1253,7 @@ dependencies = [
  "approx",
  "env_logger",
  "faer",
+ "libloading",
  "log",
  "nalgebra",
  "num-dual",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -32,6 +32,7 @@ crate-type = ["cdylib", "rlib"]
 [dependencies]
 log = "0.4"
 env_logger = "0.11"
+libloading = "0.8"
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 faer = { version = "0.20", optional = true }

--- a/examples/cho_benchmark.rs
+++ b/examples/cho_benchmark.rs
@@ -138,7 +138,13 @@ fn main() {
             std::process::exit(1);
         }
     };
-    let problem = NlProblem::from_nl_data(nl_data);
+    let problem = match NlProblem::from_nl_data(nl_data) {
+        Ok(p) => p,
+        Err(e) => {
+            eprintln!("Error: {}", e);
+            std::process::exit(1);
+        }
+    };
     let n = problem.num_variables();
     let m = problem.num_constraints();
 

--- a/examples/probe_external.rs
+++ b/examples/probe_external.rs
@@ -1,0 +1,31 @@
+//! Diagnostic: dlopen an AMPL external-function library and list its
+//! registered functions.
+//!
+//! Usage: cargo run --example probe_external -- <path/to/library.dylib>
+
+use ripopt::nl::external::ExternalLibrary;
+use std::path::PathBuf;
+
+fn main() {
+    let args: Vec<String> = std::env::args().collect();
+    let path = if args.len() >= 2 {
+        PathBuf::from(&args[1])
+    } else {
+        PathBuf::from(std::env::var_os("HOME").expect("HOME not set"))
+            .join(".idaes/bin/general_helmholtz_external.dylib")
+    };
+    let lib = match ExternalLibrary::load(&path) {
+        Ok(l) => l,
+        Err(e) => {
+            eprintln!("load failed: {e}");
+            std::process::exit(1);
+        }
+    };
+    let mut names: Vec<String> = lib.function_names().map(|s| s.to_string()).collect();
+    names.sort();
+    println!("{} functions registered in {}:", names.len(), path.display());
+    for n in &names {
+        let rf = lib.get(n).unwrap();
+        println!("  {:<24} type={} nargs={}", n, rf.ty, rf.nargs);
+    }
+}

--- a/src/bin/ripopt_ampl.rs
+++ b/src/bin/ripopt_ampl.rs
@@ -60,7 +60,13 @@ fn main() {
     let n_vars = nl_data.header.n_vars;
     let n_constrs = nl_data.header.n_constrs;
 
-    let problem = NlProblem::from_nl_data(nl_data);
+    let problem = match NlProblem::from_nl_data(nl_data) {
+        Ok(p) => p,
+        Err(e) => {
+            eprintln!("Error: {}", e);
+            std::process::exit(1);
+        }
+    };
 
     // Solve
     let result = ripopt::solve(&problem, &options);

--- a/src/nl/autodiff.rs
+++ b/src/nl/autodiff.rs
@@ -859,6 +859,9 @@ fn build_recursive(
             ops.push(TapeOp::Const(0.0));
             _idx
         }
+        ExprNode::Funcall { .. } => unreachable!(
+            "ExprNode::Funcall should have been rejected by NlProblem::from_nl_data"
+        ),
     }
 }
 
@@ -1035,6 +1038,9 @@ fn build_recursive_cached(
             ops.push(TapeOp::Const(0.0));
             idx
         }
+        ExprNode::Funcall { .. } => unreachable!(
+            "ExprNode::Funcall should have been rejected by NlProblem::from_nl_data"
+        ),
     }
 }
 

--- a/src/nl/autodiff.rs
+++ b/src/nl/autodiff.rs
@@ -1,4 +1,37 @@
+use std::collections::HashMap;
+use std::sync::Arc;
+
 use super::expr::{BinaryOp, ExprNode, NaryOp, UnaryOp};
+use super::external::{ExternalArg, ExternalLibrary};
+
+/// One argument to an AMPL external (imported) function call on the tape.
+///
+/// The AMPL `arglist` ABI preserves the positional order of arguments while
+/// routing reals through `ra[]` and strings through `sa[]`. We mirror that:
+/// real args are represented as tape indices so their values are fetched
+/// from the running `vals[]`, while string args are owned literals.
+#[derive(Debug, Clone)]
+pub enum FuncallArg {
+    /// Index into the tape — real-valued child result.
+    Tape(usize),
+    /// String literal passed verbatim to the external library.
+    Str(String),
+}
+
+/// Resolution of NL-declared `ImportedFunc` ids to a live shared library
+/// plus the name the library registered under. Produced once in
+/// `NlProblem::from_nl_data` and consumed by tape builders.
+#[derive(Default, Clone)]
+pub struct ExternalResolver {
+    /// `Funcall { id }` -> (library, registered function name).
+    pub funcs_by_id: HashMap<usize, (Arc<ExternalLibrary>, String)>,
+}
+
+impl ExternalResolver {
+    pub fn is_empty(&self) -> bool {
+        self.funcs_by_id.is_empty()
+    }
+}
 
 /// A single operation in the flattened tape.
 #[derive(Debug, Clone)]
@@ -34,6 +67,13 @@ pub enum TapeOp {
     Asinh(usize),
     Acosh(usize),
     Atanh(usize),
+    /// AMPL imported (external) function call. The library is kept alive
+    /// by the Arc; `name` is used to dispatch to the registered `rfunc`.
+    Funcall {
+        lib: Arc<ExternalLibrary>,
+        name: String,
+        args: Vec<FuncallArg>,
+    },
 }
 
 /// Flattened expression tape for efficient forward evaluation and reverse-mode AD.
@@ -51,13 +91,29 @@ pub struct CommonExprCache {
 }
 
 impl CommonExprCache {
-    /// Build a cache of all common expression tapes.
+    /// Build a cache of all common expression tapes (no external functions).
     pub fn build(common_exprs: &[ExprNode], n_vars: usize) -> Self {
+        Self::build_with_externals(common_exprs, n_vars, &ExternalResolver::default())
+    }
+
+    /// Build a cache of all common expression tapes, resolving AMPL external
+    /// function calls via `resolver`.
+    pub fn build_with_externals(
+        common_exprs: &[ExprNode],
+        n_vars: usize,
+        resolver: &ExternalResolver,
+    ) -> Self {
         let mut entries: Vec<Option<(Vec<TapeOp>, usize)>> = Vec::with_capacity(common_exprs.len());
-        // Build each common expression tape, allowing it to reference earlier ones
         for i in 0..common_exprs.len() {
             let mut ops = Vec::new();
-            let result_idx = build_recursive_cached(&common_exprs[i], common_exprs, n_vars, &mut ops, &entries);
+            let result_idx = build_recursive_cached(
+                &common_exprs[i],
+                common_exprs,
+                n_vars,
+                &mut ops,
+                &entries,
+                resolver,
+            );
             entries.push(Some((ops, result_idx)));
         }
         CommonExprCache { entries }
@@ -65,18 +121,58 @@ impl CommonExprCache {
 }
 
 impl Tape {
-    /// Build a tape from an expression tree.
-    /// Common expressions are inlined (substituted) when encountered.
+    /// Build a tape from an expression tree (no external functions).
     pub fn build(expr: &ExprNode, common_exprs: &[ExprNode], n_vars: usize) -> Self {
+        Self::build_with_externals(expr, common_exprs, n_vars, &ExternalResolver::default())
+    }
+
+    /// Build a tape from an expression tree, resolving any AMPL external
+    /// function calls via `resolver`.
+    pub fn build_with_externals(
+        expr: &ExprNode,
+        common_exprs: &[ExprNode],
+        n_vars: usize,
+        resolver: &ExternalResolver,
+    ) -> Self {
         let mut ops = Vec::new();
-        build_recursive(expr, common_exprs, n_vars, &mut ops);
+        build_recursive(expr, common_exprs, n_vars, &mut ops, resolver);
         Tape { ops, n_vars }
     }
 
-    /// Build a tape using pre-cached common expressions (avoids exponential blowup).
-    pub fn build_cached(expr: &ExprNode, common_exprs: &[ExprNode], n_vars: usize, cache: &CommonExprCache) -> Self {
+    /// Build a tape using pre-cached common expressions (no externals).
+    pub fn build_cached(
+        expr: &ExprNode,
+        common_exprs: &[ExprNode],
+        n_vars: usize,
+        cache: &CommonExprCache,
+    ) -> Self {
+        Self::build_cached_with_externals(
+            expr,
+            common_exprs,
+            n_vars,
+            cache,
+            &ExternalResolver::default(),
+        )
+    }
+
+    /// Build a tape using pre-cached common expressions, resolving AMPL
+    /// external function calls via `resolver`.
+    pub fn build_cached_with_externals(
+        expr: &ExprNode,
+        common_exprs: &[ExprNode],
+        n_vars: usize,
+        cache: &CommonExprCache,
+        resolver: &ExternalResolver,
+    ) -> Self {
         let mut ops = Vec::new();
-        build_recursive_cached(expr, common_exprs, n_vars, &mut ops, &cache.entries);
+        build_recursive_cached(
+            expr,
+            common_exprs,
+            n_vars,
+            &mut ops,
+            &cache.entries,
+            resolver,
+        );
         Tape { ops, n_vars }
     }
 
@@ -123,6 +219,15 @@ impl Tape {
                 TapeOp::Asinh(a) => vals[*a].asinh(),
                 TapeOp::Acosh(a) => vals[*a].acosh(),
                 TapeOp::Atanh(a) => vals[*a].atanh(),
+                TapeOp::Funcall { lib, name, args } => {
+                    let call_args = funcall_ext_args(args, &vals);
+                    let res = lib
+                        .eval(name, &call_args, false, false)
+                        .unwrap_or_else(|e| {
+                            panic!("external function '{name}' forward eval failed: {e}")
+                        });
+                    res.value
+                }
             };
             vals.push(v);
         }
@@ -295,6 +400,25 @@ impl Tape {
                 TapeOp::Atanh(j) => {
                     adj[*j] += a / (1.0 - vals[*j] * vals[*j]);
                 }
+                TapeOp::Funcall { lib, name, args } => {
+                    // Re-enter the library with want_derivs=true to get df/dx_k
+                    // for each real arg k (in `ra[]` order, which matches the
+                    // order of FuncallArg::Tape entries).
+                    let call_args = funcall_ext_args(args, vals);
+                    let res = lib
+                        .eval(name, &call_args, true, false)
+                        .unwrap_or_else(|e| {
+                            panic!("external function '{name}' reverse eval failed: {e}")
+                        });
+                    let derivs = res.derivs.expect("want_derivs=true returns derivs");
+                    let mut k = 0usize;
+                    for arg in args {
+                        if let FuncallArg::Tape(idx) = arg {
+                            adj[*idx] += a * derivs[k];
+                            k += 1;
+                        }
+                    }
+                }
             }
         }
     }
@@ -358,6 +482,25 @@ impl Tape {
                 TapeOp::Asinh(a) => dot[*a] / (vals[*a] * vals[*a] + 1.0).sqrt(),
                 TapeOp::Acosh(a) => dot[*a] / (vals[*a] * vals[*a] - 1.0).sqrt(),
                 TapeOp::Atanh(a) => dot[*a] / (1.0 - vals[*a] * vals[*a]),
+                TapeOp::Funcall { lib, name, args } => {
+                    // dot[i] = sum_k (df/dx_k) * dot[arg_k_tape_idx]
+                    let call_args = funcall_ext_args(args, vals);
+                    let res = lib
+                        .eval(name, &call_args, true, false)
+                        .unwrap_or_else(|e| {
+                            panic!("external function '{name}' tangent eval failed: {e}")
+                        });
+                    let derivs = res.derivs.expect("want_derivs=true returns derivs");
+                    let mut acc = 0.0;
+                    let mut k = 0usize;
+                    for arg in args {
+                        if let FuncallArg::Tape(idx) = arg {
+                            acc += derivs[k] * dot[*idx];
+                            k += 1;
+                        }
+                    }
+                    acc
+                }
             };
         }
         dot
@@ -619,6 +762,46 @@ impl Tape {
                         adj[*a] += w / d;
                         adj_dot[*a] += wd / d + w * (2.0 * u / (d * d)) * dot[*a];
                     }
+                    TapeOp::Funcall { lib, name, args } => {
+                        // Full second-order propagation through an external
+                        // function. Treat F: R^nr -> R; let p_k = dF/dra[k]
+                        // and H_kl = d^2F/dra[k]/dra[l] (packed upper-tri).
+                        //
+                        //   adj[ti[k]]     += w * p_k
+                        //   adj_dot[ti[k]] += wd * p_k
+                        //                    + w * sum_l ( H_kl * dot[ti[l]] )
+                        let call_args = funcall_ext_args(args, &v);
+                        let res = lib
+                            .eval(name, &call_args, true, true)
+                            .unwrap_or_else(|e| {
+                                panic!(
+                                    "external function '{name}' 2nd-order eval failed: {e}"
+                                )
+                            });
+                        let derivs =
+                            res.derivs.expect("want_derivs=true returns derivs");
+                        let hes = res.hessian.expect("want_hes=true returns hessian");
+
+                        // Collect the tape indices of real args (in ra[] order).
+                        let real_tape: Vec<usize> = args
+                            .iter()
+                            .filter_map(|a| match a {
+                                FuncallArg::Tape(t) => Some(*t),
+                                FuncallArg::Str(_) => None,
+                            })
+                            .collect();
+
+                        for (k, &tk) in real_tape.iter().enumerate() {
+                            adj[tk] += w * derivs[k];
+                            let mut second_term = 0.0;
+                            for (l, &tl) in real_tape.iter().enumerate() {
+                                let (lo, hi) = if k <= l { (k, l) } else { (l, k) };
+                                let h_kl = hes[lo + hi * (hi + 1) / 2];
+                                second_term += h_kl * dot[tl];
+                            }
+                            adj_dot[tk] += wd * derivs[k] + w * second_term;
+                        }
+                    }
                 }
             }
         }
@@ -708,12 +891,39 @@ impl Tape {
                     emit_self(&var_sets[*a], &mut hess_pairs);
                     var_sets[*a].clone()
                 }
+                // External function: treat as a dense block over the union
+                // of variables influencing any real-valued argument. String
+                // args contribute nothing to sparsity.
+                TapeOp::Funcall { args, .. } => {
+                    let mut combined: BTreeSet<usize> = BTreeSet::new();
+                    for arg in args {
+                        if let FuncallArg::Tape(t) = arg {
+                            for &v in &var_sets[*t] {
+                                combined.insert(v);
+                            }
+                        }
+                    }
+                    emit_self(&combined, &mut hess_pairs);
+                    combined
+                }
             };
             var_sets.push(vset);
         }
 
         hess_pairs
     }
+}
+
+/// Build the `ExternalArg` slice passed to `ExternalLibrary::eval`, reading
+/// current real-arg values from the running tape `vals[]`. The positional
+/// ordering (mixed real/string) is preserved exactly.
+fn funcall_ext_args<'a>(args: &'a [FuncallArg], vals: &[f64]) -> Vec<ExternalArg<'a>> {
+    args.iter()
+        .map(|a| match a {
+            FuncallArg::Tape(t) => ExternalArg::Real(vals[*t]),
+            FuncallArg::Str(s) => ExternalArg::Str(s.as_str()),
+        })
+        .collect()
 }
 
 /// Recursively flatten an expression tree into tape operations.
@@ -723,6 +933,7 @@ fn build_recursive(
     common_exprs: &[ExprNode],
     n_vars: usize,
     ops: &mut Vec<TapeOp>,
+    resolver: &ExternalResolver,
 ) -> usize {
     match expr {
         ExprNode::Const(c) => {
@@ -739,7 +950,7 @@ fn build_recursive(
                 // Common sub-expression: inline it
                 let ce_idx = *i - n_vars;
                 if ce_idx < common_exprs.len() {
-                    build_recursive(&common_exprs[ce_idx], common_exprs, n_vars, ops)
+                    build_recursive(&common_exprs[ce_idx], common_exprs, n_vars, ops, resolver)
                 } else {
                     // Missing common expr, treat as 0
                     let idx = ops.len();
@@ -749,8 +960,8 @@ fn build_recursive(
             }
         }
         ExprNode::Binary(op, left, right) => {
-            let l = build_recursive(left, common_exprs, n_vars, ops);
-            let r = build_recursive(right, common_exprs, n_vars, ops);
+            let l = build_recursive(left, common_exprs, n_vars, ops, resolver);
+            let r = build_recursive(right, common_exprs, n_vars, ops, resolver);
             let idx = ops.len();
             ops.push(match op {
                 BinaryOp::Add => TapeOp::Add(l, r),
@@ -766,7 +977,7 @@ fn build_recursive(
             idx
         }
         ExprNode::Unary(op, arg) => {
-            let a = build_recursive(arg, common_exprs, n_vars, ops);
+            let a = build_recursive(arg, common_exprs, n_vars, ops, resolver);
             let idx = ops.len();
             ops.push(match op {
                 UnaryOp::Abs => TapeOp::Abs(a),
@@ -803,9 +1014,9 @@ fn build_recursive(
                 return idx;
             }
             // For Sum, chain binary adds. For Min/Max, use Less or binary comparisons.
-            let mut acc = build_recursive(&args[0], common_exprs, n_vars, ops);
+            let mut acc = build_recursive(&args[0], common_exprs, n_vars, ops, resolver);
             for arg in &args[1..] {
-                let next = build_recursive(arg, common_exprs, n_vars, ops);
+                let next = build_recursive(arg, common_exprs, n_vars, ops, resolver);
                 match op {
                     NaryOp::Sum => {
                         let idx = ops.len();
@@ -834,24 +1045,11 @@ fn build_recursive(
             acc
         }
         ExprNode::If(cond, then_expr, else_expr) => {
-            // Evaluate condition, then choose branch.
-            // For AD: treat as piecewise smooth, differentiate through the active branch.
-            // We evaluate the condition using forward eval, but in the tape we need to
-            // include both branches. For simplicity, we'll use a runtime branch:
-            // just evaluate both and select. This is wasteful but correct for AD.
-            // Actually, for the tape approach, we need a conditional op.
-            // Simpler: don't tape if-then-else; fall back to tree evaluation.
-            // For now, inline both branches and use: cond > 0 ? then : else
-            // approximated as: then * step(cond) + else * (1 - step(cond))
-            // But this has zero gradient through step.
-            //
-            // Pragmatic: just build both branches into tape and add a Select op.
-            // For AD, differentiate through the active branch only.
-            // If-then-else: evaluate all branches, approximate as "then" branch
-            // for AD. Most NLP problems don't use if-then-else.
-            let _c = build_recursive(cond, common_exprs, n_vars, ops);
-            let t = build_recursive(then_expr, common_exprs, n_vars, ops);
-            let _e = build_recursive(else_expr, common_exprs, n_vars, ops);
+            // If-then-else: approximate as "then" branch for AD; most NLP
+            // problems don't use it meaningfully.
+            let _c = build_recursive(cond, common_exprs, n_vars, ops, resolver);
+            let t = build_recursive(then_expr, common_exprs, n_vars, ops, resolver);
+            let _e = build_recursive(else_expr, common_exprs, n_vars, ops, resolver);
             t
         }
         ExprNode::StringLiteral(_) => {
@@ -859,9 +1057,36 @@ fn build_recursive(
             ops.push(TapeOp::Const(0.0));
             _idx
         }
-        ExprNode::Funcall { .. } => unreachable!(
-            "ExprNode::Funcall should have been rejected by NlProblem::from_nl_data"
-        ),
+        ExprNode::Funcall { id, args } => {
+            let (lib, name) = resolver.funcs_by_id.get(id).cloned().unwrap_or_else(|| {
+                panic!(
+                    "build_recursive: no ExternalResolver entry for Funcall id={id}; \
+                     NlProblem::from_nl_data should have loaded this library"
+                )
+            });
+            // Positional args: strings go through verbatim; every other
+            // ExprNode is built recursively and stored as a tape index.
+            let built_args: Vec<FuncallArg> = args
+                .iter()
+                .map(|a| match a {
+                    ExprNode::StringLiteral(s) => FuncallArg::Str(s.clone()),
+                    other => FuncallArg::Tape(build_recursive(
+                        other,
+                        common_exprs,
+                        n_vars,
+                        ops,
+                        resolver,
+                    )),
+                })
+                .collect();
+            let idx = ops.len();
+            ops.push(TapeOp::Funcall {
+                lib,
+                name,
+                args: built_args,
+            });
+            idx
+        }
     }
 }
 
@@ -899,6 +1124,17 @@ fn remap_op(op: &TapeOp, offset: usize) -> TapeOp {
         TapeOp::Asinh(a) => TapeOp::Asinh(a + offset),
         TapeOp::Acosh(a) => TapeOp::Acosh(a + offset),
         TapeOp::Atanh(a) => TapeOp::Atanh(a + offset),
+        TapeOp::Funcall { lib, name, args } => TapeOp::Funcall {
+            lib: lib.clone(),
+            name: name.clone(),
+            args: args
+                .iter()
+                .map(|a| match a {
+                    FuncallArg::Tape(t) => FuncallArg::Tape(t + offset),
+                    FuncallArg::Str(s) => FuncallArg::Str(s.clone()),
+                })
+                .collect(),
+        },
     }
 }
 
@@ -910,6 +1146,7 @@ fn build_recursive_cached(
     n_vars: usize,
     ops: &mut Vec<TapeOp>,
     cache: &[Option<(Vec<TapeOp>, usize)>],
+    resolver: &ExternalResolver,
 ) -> usize {
     match expr {
         ExprNode::Const(c) => {
@@ -945,8 +1182,8 @@ fn build_recursive_cached(
             }
         }
         ExprNode::Binary(op, left, right) => {
-            let l = build_recursive_cached(left, common_exprs, n_vars, ops, cache);
-            let r = build_recursive_cached(right, common_exprs, n_vars, ops, cache);
+            let l = build_recursive_cached(left, common_exprs, n_vars, ops, cache, resolver);
+            let r = build_recursive_cached(right, common_exprs, n_vars, ops, cache, resolver);
             let idx = ops.len();
             ops.push(match op {
                 BinaryOp::Add => TapeOp::Add(l, r),
@@ -962,7 +1199,7 @@ fn build_recursive_cached(
             idx
         }
         ExprNode::Unary(op, arg) => {
-            let a = build_recursive_cached(arg, common_exprs, n_vars, ops, cache);
+            let a = build_recursive_cached(arg, common_exprs, n_vars, ops, cache, resolver);
             let idx = ops.len();
             ops.push(match op {
                 UnaryOp::Abs => TapeOp::Abs(a),
@@ -998,9 +1235,9 @@ fn build_recursive_cached(
                 }));
                 return idx;
             }
-            let mut acc = build_recursive_cached(&args[0], common_exprs, n_vars, ops, cache);
+            let mut acc = build_recursive_cached(&args[0], common_exprs, n_vars, ops, cache, resolver);
             for arg in &args[1..] {
-                let next = build_recursive_cached(arg, common_exprs, n_vars, ops, cache);
+                let next = build_recursive_cached(arg, common_exprs, n_vars, ops, cache, resolver);
                 match op {
                     NaryOp::Sum => {
                         let idx = ops.len();
@@ -1028,9 +1265,9 @@ fn build_recursive_cached(
             acc
         }
         ExprNode::If(cond, then_expr, else_expr) => {
-            let _c = build_recursive_cached(cond, common_exprs, n_vars, ops, cache);
-            let t = build_recursive_cached(then_expr, common_exprs, n_vars, ops, cache);
-            let _e = build_recursive_cached(else_expr, common_exprs, n_vars, ops, cache);
+            let _c = build_recursive_cached(cond, common_exprs, n_vars, ops, cache, resolver);
+            let t = build_recursive_cached(then_expr, common_exprs, n_vars, ops, cache, resolver);
+            let _e = build_recursive_cached(else_expr, common_exprs, n_vars, ops, cache, resolver);
             t
         }
         ExprNode::StringLiteral(_) => {
@@ -1038,9 +1275,35 @@ fn build_recursive_cached(
             ops.push(TapeOp::Const(0.0));
             idx
         }
-        ExprNode::Funcall { .. } => unreachable!(
-            "ExprNode::Funcall should have been rejected by NlProblem::from_nl_data"
-        ),
+        ExprNode::Funcall { id, args } => {
+            let (lib, name) = resolver.funcs_by_id.get(id).cloned().unwrap_or_else(|| {
+                panic!(
+                    "build_recursive_cached: no ExternalResolver entry for Funcall \
+                     id={id}; NlProblem::from_nl_data should have loaded this library"
+                )
+            });
+            let built_args: Vec<FuncallArg> = args
+                .iter()
+                .map(|a| match a {
+                    ExprNode::StringLiteral(s) => FuncallArg::Str(s.clone()),
+                    other => FuncallArg::Tape(build_recursive_cached(
+                        other,
+                        common_exprs,
+                        n_vars,
+                        ops,
+                        cache,
+                        resolver,
+                    )),
+                })
+                .collect();
+            let idx = ops.len();
+            ops.push(TapeOp::Funcall {
+                lib,
+                name,
+                args: built_args,
+            });
+            idx
+        }
     }
 }
 

--- a/src/nl/expr.rs
+++ b/src/nl/expr.rs
@@ -58,6 +58,9 @@ pub enum ExprNode {
     If(Box<ExprNode>, Box<ExprNode>, Box<ExprNode>),
     /// String literal (ignored in evaluation).
     StringLiteral(String),
+    /// AMPL imported (external) function call. Cannot be evaluated natively —
+    /// callers must surface an error before any evaluation occurs.
+    Funcall { id: usize, args: Vec<ExprNode> },
 }
 
 /// Parse a prefix-notation expression tree from NL file lines.
@@ -95,6 +98,21 @@ pub fn parse_expr<'a>(lines: &mut impl Iterator<Item = &'a str>) -> Result<ExprN
             .parse()
             .map_err(|e| format!("Bad opcode '{}': {}", &token[1..], e))?;
         parse_op(opcode, lines)
+    } else if token.starts_with('f') {
+        // AMPL imported (external) function call: `f<id> <nargs>` on one line,
+        // followed by nargs child expressions (each possibly multi-line).
+        let rest = &token[1..];
+        let mut parts = rest.split_whitespace();
+        let id_str = parts.next().ok_or_else(|| format!("Missing function id in '{}'", token))?;
+        let nargs_str = parts.next().ok_or_else(|| format!("Missing nargs in '{}'", token))?;
+        let id: usize = id_str
+            .parse()
+            .map_err(|e| format!("Bad function id '{}': {}", id_str, e))?;
+        let nargs: usize = nargs_str
+            .parse()
+            .map_err(|e| format!("Bad funcall nargs '{}': {}", nargs_str, e))?;
+        let args: Result<Vec<_>, _> = (0..nargs).map(|_| parse_expr(lines)).collect();
+        Ok(ExprNode::Funcall { id, args: args? })
     } else {
         Err(format!("Unknown expression token: '{}'", token))
     }
@@ -265,5 +283,8 @@ pub fn eval_expr(node: &ExprNode, vals: &[f64]) -> f64 {
             }
         }
         ExprNode::StringLiteral(_) => 0.0,
+        ExprNode::Funcall { .. } => unreachable!(
+            "ExprNode::Funcall should have been rejected by NlProblem::from_nl_data"
+        ),
     }
 }

--- a/src/nl/external.rs
+++ b/src/nl/external.rs
@@ -608,6 +608,12 @@ mod tests {
         }
     }
 
+    fn idaes_functions_dylib() -> Option<std::path::PathBuf> {
+        let home = std::env::var_os("HOME")?;
+        let p = std::path::PathBuf::from(home).join(".idaes/bin/functions.dylib");
+        if p.exists() { Some(p) } else { None }
+    }
+
     fn idaes_params_dir() -> Option<String> {
         let home = std::env::var_os("HOME")?;
         let p = std::path::PathBuf::from(home).join(
@@ -728,5 +734,70 @@ mod tests {
         for (i, h) in hes.iter().enumerate() {
             assert!(h.is_finite(), "hes[{i}] = {h} not finite");
         }
+    }
+
+    /// cbrt from IDAES functions.dylib is type=0 (no strings), nargs=1
+    /// (exact positive arity) — a code path the Helmholtz fixture never
+    /// exercises. Verify value, derivative, and second derivative match
+    /// the closed form at x = 8: cbrt(8) = 2, d/dx = 1/12, d2/dx2 = -1/144.
+    #[test]
+    fn eval_cbrt_matches_closed_form() {
+        let Some(path) = idaes_functions_dylib() else {
+            eprintln!("skipping: IDAES functions.dylib not present");
+            return;
+        };
+        let lib = ExternalLibrary::load(&path).expect("load");
+        let rf = lib.get("cbrt").expect("cbrt registered");
+        assert_eq!(rf.ty, 0, "cbrt should be FUNCADD_REAL_VALUED (type=0)");
+        assert_eq!(rf.nargs, 1, "cbrt should have exact arity 1");
+
+        let args = [ExternalArg::Real(8.0)];
+        let res = lib.eval("cbrt", &args, true, true).expect("eval");
+        let derivs = res.derivs.expect("derivs requested");
+        let hes = res.hessian.expect("hessian requested");
+        assert_eq!(derivs.len(), 1);
+        assert_eq!(hes.len(), 1, "nr=1 -> packed Hessian length 1");
+
+        // cbrt(8) = 2
+        assert!((res.value - 2.0).abs() < 1e-12, "value {}", res.value);
+        // d/dx cbrt(x) = 1/(3 x^(2/3)); at x=8, that's 1/12
+        assert!((derivs[0] - 1.0 / 12.0).abs() < 1e-12, "deriv {}", derivs[0]);
+        // d2/dx2 cbrt(x) = -2/(9 x^(5/3)); at x=8, that's -2/288 = -1/144
+        assert!((hes[0] + 1.0 / 144.0).abs() < 1e-12, "hes {}", hes[0]);
+    }
+
+    /// Exact positive arity is enforced: cbrt expects nargs=1, so calling
+    /// with 0 or 2 reals must error cleanly.
+    #[test]
+    fn eval_cbrt_arity_mismatch_errors() {
+        let Some(path) = idaes_functions_dylib() else {
+            eprintln!("skipping: IDAES functions.dylib not present");
+            return;
+        };
+        let lib = ExternalLibrary::load(&path).expect("load");
+        let too_few: [ExternalArg; 0] = [];
+        assert!(lib.eval("cbrt", &too_few, false, false).is_err());
+        let too_many = [ExternalArg::Real(1.0), ExternalArg::Real(2.0)];
+        assert!(lib.eval("cbrt", &too_many, false, false).is_err());
+    }
+
+    /// cbrt is type=0 — no string args allowed. Passing a string must be
+    /// rejected by our eval, not forwarded to the library.
+    #[test]
+    fn eval_cbrt_rejects_string_arg() {
+        let Some(path) = idaes_functions_dylib() else {
+            eprintln!("skipping: IDAES functions.dylib not present");
+            return;
+        };
+        let lib = ExternalLibrary::load(&path).expect("load");
+        let args = [ExternalArg::Str("nope")];
+        let err = lib
+            .eval("cbrt", &args, false, false)
+            .err()
+            .expect("string arg to type=0 function must error");
+        assert!(
+            err.to_lowercase().contains("string"),
+            "error should mention strings, got: {err}"
+        );
     }
 }

--- a/src/nl/external.rs
+++ b/src/nl/external.rs
@@ -1,0 +1,732 @@
+//! AMPL imported (external) function support via the `funcadd_ASL` ABI.
+//!
+//! This module implements enough of AMPL's `funcadd.h` ABI to:
+//!
+//! 1. `dlopen` a user-supplied shared library;
+//! 2. resolve the `funcadd_ASL` symbol and call it;
+//! 3. receive registration callbacks of the form `Addfunc(name, rfunc, type,
+//!    nargs, funcinfo, ae)` and record them;
+//! 4. later call back into the registered `rfunc` with an `arglist` to obtain
+//!    function values, gradients, and Hessians.
+//!
+//! The `AmplExports` and `Arglist` struct layouts are taken from
+//! AMPL-MP/ASL `funcadd.h`; cross-checked against the ctypes mapping in
+//! `pyomo.core.base.external`. Fields we don't populate are left null —
+//! Pyomo does the same and it is sufficient for IDAES's Helmholtz library
+//! (see issue #15).
+//!
+//! All unsafe FFI is contained in this module. Public surface is safe.
+
+use std::collections::HashMap;
+use std::ffi::{c_char, c_int, c_long, c_void, CStr, CString};
+use std::path::Path;
+use std::ptr;
+use std::sync::{Arc, Mutex, OnceLock};
+
+use libloading::{Library, Symbol};
+
+/// Process-wide lock serialising every call that crosses the AMPL external
+/// ABI. Real AMPL libraries (e.g. IDAES general_helmholtz) keep mutable
+/// global state (cached parameters, tabulated lookups) and are not safe for
+/// concurrent entry. Python's `pyomo.core.base.external` relies on the GIL
+/// for the same guarantee.
+fn ampl_lock() -> &'static Mutex<()> {
+    static LOCK: OnceLock<Mutex<()>> = OnceLock::new();
+    LOCK.get_or_init(|| Mutex::new(()))
+}
+
+/// FUNCADD_TYPE bits (mirrors `funcadd.h`).
+pub const FUNCADD_REAL_VALUED: i32 = 0;
+/// Set if the function consumes string arguments. Value is still real.
+pub const FUNCADD_STRING_ARGS: i32 = 1;
+/// Set if the function is allowed to have a variable number of args.
+pub const FUNCADD_OUTPUT_ARGS: i32 = 2;
+pub const FUNCADD_RANDOM_VALUED: i32 = 4;
+
+/// The `arglist` struct from AMPL's `funcadd.h`. Layout must match exactly.
+#[repr(C)]
+pub struct Arglist {
+    pub n: c_int,                        // number of args
+    pub nr: c_int,                       // number of real input args
+    pub at: *mut c_int,                  // argument types
+    pub ra: *mut f64,                    // pure real args (IN/OUT/INOUT)
+    pub sa: *mut *const c_char,          // symbolic IN args
+    pub derivs: *mut f64,                // partial derivatives (if non-null)
+    pub hes: *mut f64,                   // second partials (if non-null)
+    pub dig: *mut c_char,                // skip-derivatives flags
+    pub funcinfo: *mut c_void,           // per-function cookie (set by Addfunc)
+    pub ae: *mut AmplExports,            // points back at our AmplExports
+    pub f: *mut c_void,                  // AMPL-internal
+    pub tva: *mut c_void,                // AMPL-internal
+    pub errmsg: *mut c_char,             // error description set by the function
+    pub tmi: *mut c_void,                // Tempmem cookie
+    pub private: *mut c_char,
+    pub nin: c_int,
+    pub nout: c_int,
+    pub nsin: c_int,
+    pub nsout: c_int,
+}
+
+/// Pointer to a user-defined real-valued function, matching
+/// `typedef real (*rfunc)(arglist*)`.
+pub type Rfunc = unsafe extern "C" fn(*mut Arglist) -> f64;
+
+/// Pointer to the `Addfunc` callback provided by the caller.
+pub type AddfuncFn = unsafe extern "C" fn(
+    name: *const c_char,
+    f: Rfunc,
+    ty: c_int,
+    nargs: c_int,
+    funcinfo: *mut c_void,
+    ae: *mut AmplExports,
+);
+
+/// Pointer to the `RandSeedSetter` callback.
+pub type RandSeedSetter = unsafe extern "C" fn(*mut c_void, std::os::raw::c_ulong);
+
+/// Pointer to the `Addrandinit` callback.
+pub type AddrandinitFn = unsafe extern "C" fn(
+    ae: *mut AmplExports,
+    setter: RandSeedSetter,
+    v: *mut c_void,
+);
+
+/// Pointer to the `AtReset` callback.
+pub type AtResetFn = unsafe extern "C" fn(
+    ae: *mut AmplExports,
+    f: *mut c_void,
+    v: *mut c_void,
+);
+
+/// The `AmplExports` struct from AMPL's `funcadd.h`. Layout must match
+/// exactly. Function pointers we don't implement are held as `*mut c_void`
+/// (null) — AMPL's ABI does not require a caller to populate them unless the
+/// loaded library actually invokes them.
+#[repr(C)]
+pub struct AmplExports {
+    pub std_err: *mut c_void,
+    pub addfunc: Option<AddfuncFn>,
+    pub asl_date: c_long,
+    pub fprintf: *mut c_void,
+    pub printf: *mut c_void,
+    pub sprintf: *mut c_void,
+    pub vfprintf: *mut c_void,
+    pub vsprintf: *mut c_void,
+    pub strtod: *mut c_void,
+    pub crypto: *mut c_void,
+    pub asl: *mut c_char,
+    pub at_exit: *mut c_void,
+    pub at_reset: Option<AtResetFn>,
+    pub tempmem: *mut c_void,
+    pub add_table_handler: *mut c_void,
+    pub private_ae: *mut c_char,
+    pub qsortv: *mut c_void,
+
+    pub std_in: *mut c_void,
+    pub std_out: *mut c_void,
+    pub clearerr: *mut c_void,
+    pub fclose: *mut c_void,
+    pub fdopen: *mut c_void,
+    pub feof: *mut c_void,
+    pub ferror: *mut c_void,
+    pub fflush: *mut c_void,
+    pub fgetc: *mut c_void,
+    pub fgets: *mut c_void,
+    pub fileno: *mut c_void,
+    pub fopen: *mut c_void,
+    pub fputc: *mut c_void,
+    pub fputs: *mut c_void,
+    pub fread: *mut c_void,
+    pub freopen: *mut c_void,
+    pub fscanf: *mut c_void,
+    pub fseek: *mut c_void,
+    pub ftell: *mut c_void,
+    pub fwrite: *mut c_void,
+    pub pclose: *mut c_void,
+    pub perror: *mut c_void,
+    pub popen: *mut c_void,
+    pub puts: *mut c_void,
+    pub rewind: *mut c_void,
+    pub scanf: *mut c_void,
+    pub setbuf: *mut c_void,
+    pub setvbuf: *mut c_void,
+    pub sscanf: *mut c_void,
+    pub tempnam: *mut c_void,
+    pub tmpfile: *mut c_void,
+    pub tmpnam: *mut c_void,
+    pub ungetc: *mut c_void,
+    pub ai: *mut c_void,
+    pub getenv: *mut c_void,
+    pub breakfunc: *mut c_void,
+    pub breakarg: *mut c_char,
+
+    // Items available with ASLdate >= 20020501.
+    pub snprintf: *mut c_void,
+    pub vsnprintf: *mut c_void,
+
+    pub addrand: *mut c_void,
+    pub addrandinit: Option<AddrandinitFn>,
+}
+
+// SAFETY: AmplExports itself contains only raw pointers and integers. The
+// library never reads/writes it from another thread concurrently with us
+// (AMPL's model is single-threaded per problem), and we never share it
+// across threads. The Send/Sync bounds only matter because we box the
+// registry inside Arcs.
+unsafe impl Send for AmplExports {}
+unsafe impl Sync for AmplExports {}
+
+/// A function registered by a library via `Addfunc`. Mirrors the ASL
+/// `FUNCADD_TYPE` bits in `funcadd.h`.
+#[derive(Debug, Clone)]
+pub struct RegisteredFunc {
+    pub name: String,
+    pub rfunc: Rfunc,
+    /// OR of FUNCADD_TYPE bits.
+    pub ty: i32,
+    /// Declared arg count. >=0 means exactly that many, <=-1 means "at least
+    /// -(nargs+1) args".
+    pub nargs: i32,
+    /// Cookie set by the library; must be passed through to arglist.funcinfo.
+    pub funcinfo: *mut c_void,
+}
+
+// SAFETY: funcinfo is an opaque cookie owned by the library. We never
+// dereference it; we only pass it back to the library's functions, which
+// expect it. No thread-safety contract is violated by sending the struct.
+unsafe impl Send for RegisteredFunc {}
+unsafe impl Sync for RegisteredFunc {}
+
+impl std::fmt::Debug for ExternalLibrary {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("ExternalLibrary")
+            .field("funcs", &self.funcs.keys().collect::<Vec<_>>())
+            .finish()
+    }
+}
+
+/// A loaded external-function library plus its registered functions.
+pub struct ExternalLibrary {
+    /// Keep the library alive — it owns the code pages the function pointers
+    /// reference. Arc so `LoadedExternals` can share it.
+    _lib: Arc<Library>,
+    /// The AmplExports we handed to `funcadd_ASL`. Must be kept alive (pinned
+    /// in a Box) because some libraries may capture its address for later
+    /// use (e.g. for `AtReset` bookkeeping).
+    _ae: Box<AmplExports>,
+    /// Registrations collected during `funcadd_ASL`.
+    funcs: HashMap<String, RegisteredFunc>,
+}
+
+impl ExternalLibrary {
+    /// Open a shared library at `path` and invoke its `funcadd_ASL` entry
+    /// point, collecting all functions it registers.
+    pub fn load(path: &Path) -> Result<Self, String> {
+        // Serialise all ABI crossings: library init code and registration
+        // may touch global state that isn't safe under concurrent entry.
+        let _guard = ampl_lock().lock().unwrap_or_else(|e| e.into_inner());
+        // SAFETY: libloading::Library::new is unsafe because it can run
+        // arbitrary initialisers from the shared object. We trust the user's
+        // AMPLFUNC path the same way AMPL/IPOPT do.
+        let lib = unsafe { Library::new(path) }
+            .map_err(|e| format!("failed to open '{}': {}", path.display(), e))?;
+
+        // Resolve `funcadd_ASL`. AMPL's macro `#define funcadd funcadd_ASL`
+        // means every conforming library exports this symbol.
+        type FuncaddFn = unsafe extern "C" fn(*mut AmplExports);
+        let funcadd: Symbol<FuncaddFn> = unsafe { lib.get(b"funcadd_ASL\0") }
+            .map_err(|e| format!("no funcadd_ASL in '{}': {}", path.display(), e))?;
+
+        // Build an AmplExports. Most fields null — the library doesn't call
+        // them (same assumption Pyomo makes). Only the three hooks we can
+        // realistically service are set.
+        let mut ae = Box::new(AmplExports {
+            std_err: ptr::null_mut(),
+            addfunc: Some(trampoline_addfunc),
+            // ASLdate >= 20020501 unlocks the SnprintF/VsnprintF slots.
+            // Pyomo uses 20160307; mirror that.
+            asl_date: 20160307,
+            fprintf: ptr::null_mut(),
+            printf: ptr::null_mut(),
+            sprintf: ptr::null_mut(),
+            vfprintf: ptr::null_mut(),
+            vsprintf: ptr::null_mut(),
+            strtod: ptr::null_mut(),
+            crypto: ptr::null_mut(),
+            asl: ptr::null_mut(),
+            at_exit: ptr::null_mut(),
+            at_reset: Some(trampoline_atreset),
+            tempmem: ptr::null_mut(),
+            add_table_handler: ptr::null_mut(),
+            private_ae: ptr::null_mut(),
+            qsortv: ptr::null_mut(),
+            std_in: ptr::null_mut(),
+            std_out: ptr::null_mut(),
+            clearerr: ptr::null_mut(),
+            fclose: ptr::null_mut(),
+            fdopen: ptr::null_mut(),
+            feof: ptr::null_mut(),
+            ferror: ptr::null_mut(),
+            fflush: ptr::null_mut(),
+            fgetc: ptr::null_mut(),
+            fgets: ptr::null_mut(),
+            fileno: ptr::null_mut(),
+            fopen: ptr::null_mut(),
+            fputc: ptr::null_mut(),
+            fputs: ptr::null_mut(),
+            fread: ptr::null_mut(),
+            freopen: ptr::null_mut(),
+            fscanf: ptr::null_mut(),
+            fseek: ptr::null_mut(),
+            ftell: ptr::null_mut(),
+            fwrite: ptr::null_mut(),
+            pclose: ptr::null_mut(),
+            perror: ptr::null_mut(),
+            popen: ptr::null_mut(),
+            puts: ptr::null_mut(),
+            rewind: ptr::null_mut(),
+            scanf: ptr::null_mut(),
+            setbuf: ptr::null_mut(),
+            setvbuf: ptr::null_mut(),
+            sscanf: ptr::null_mut(),
+            tempnam: ptr::null_mut(),
+            tmpfile: ptr::null_mut(),
+            tmpnam: ptr::null_mut(),
+            ungetc: ptr::null_mut(),
+            ai: ptr::null_mut(),
+            getenv: ptr::null_mut(),
+            breakfunc: ptr::null_mut(),
+            breakarg: ptr::null_mut(),
+            snprintf: ptr::null_mut(),
+            vsnprintf: ptr::null_mut(),
+            addrand: ptr::null_mut(),
+            addrandinit: Some(trampoline_addrandinit),
+        });
+
+        // Drive registrations into a thread-local sink so the C trampoline
+        // has somewhere to deposit them without capturing Rust state.
+        REGISTRY_SINK.with(|sink| {
+            let mut guard = sink.borrow_mut();
+            assert!(guard.is_none(), "nested ExternalLibrary::load is not supported");
+            *guard = Some(HashMap::new());
+        });
+
+        // SAFETY: funcadd is a valid C function from the loaded library; we
+        // pass it a correctly-shaped AmplExports.
+        unsafe { funcadd(ae.as_mut()) };
+
+        let funcs = REGISTRY_SINK
+            .with(|sink| sink.borrow_mut().take())
+            .unwrap_or_default();
+
+        Ok(ExternalLibrary {
+            _lib: Arc::new(lib),
+            _ae: ae,
+            funcs,
+        })
+    }
+
+    /// Names of all functions registered by this library.
+    pub fn function_names(&self) -> impl Iterator<Item = &str> {
+        self.funcs.keys().map(|s| s.as_str())
+    }
+
+    /// Look up a registered function by name.
+    pub fn get(&self, name: &str) -> Option<&RegisteredFunc> {
+        self.funcs.get(name)
+    }
+
+    /// Evaluate a registered function with the given positional arguments.
+    ///
+    /// Arguments are encoded per the AMPL `arglist` ABI: real args are stored
+    /// in `ra[]`, string args in `sa[]`, and `at[i]` maps argument position
+    /// `i` to either a real-slot index (`at[i] >= 0`) or a string-slot index
+    /// (`at[i] < 0`, decoded as `-(at[i]+1)`).
+    ///
+    /// If `want_derivs` is set, a length-`nr` derivative buffer is allocated
+    /// and returned on success. If `want_hes` is set, a length-`nr*(nr+1)/2`
+    /// Hessian buffer is also allocated and returned. The library is told to
+    /// fill both by the non-null `arglist.derivs` / `arglist.hes` pointers.
+    pub fn eval(
+        &self,
+        name: &str,
+        args: &[ExternalArg<'_>],
+        want_derivs: bool,
+        want_hes: bool,
+    ) -> Result<EvalResult, String> {
+        let rf = self
+            .funcs
+            .get(name)
+            .ok_or_else(|| format!("no such external function '{name}'"))?;
+
+        // Validate arity against the registered signature.
+        let n = args.len() as i32;
+        if rf.nargs >= 0 {
+            if rf.nargs != n {
+                return Err(format!(
+                    "external '{name}' expects {} args, got {}",
+                    rf.nargs, n
+                ));
+            }
+        } else {
+            // Negative: minimum -(nargs+1) args.
+            let min_args = -(rf.nargs + 1);
+            if n < min_args {
+                return Err(format!(
+                    "external '{name}' expects at least {min_args} args, got {n}"
+                ));
+            }
+        }
+
+        // Bucket args: build at[], ra[], sa[] in lockstep with their indices.
+        let mut at_vec: Vec<c_int> = Vec::with_capacity(args.len());
+        let mut ra_vec: Vec<f64> = Vec::new();
+        let mut sa_owned: Vec<CString> = Vec::new();
+        for a in args {
+            match a {
+                ExternalArg::Real(x) => {
+                    at_vec.push(ra_vec.len() as c_int);
+                    ra_vec.push(*x);
+                }
+                ExternalArg::Str(s) => {
+                    let cs = CString::new(*s)
+                        .map_err(|_| format!("external '{name}' string arg contains NUL"))?;
+                    at_vec.push(-(sa_owned.len() as c_int + 1));
+                    sa_owned.push(cs);
+                }
+            }
+        }
+        let nr = ra_vec.len() as c_int;
+        let sa_ptrs: Vec<*const c_char> = sa_owned.iter().map(|s| s.as_ptr()).collect();
+
+        // If the library declared FUNCADD_STRING_ARGS we let it see sa; if it
+        // did not, the library shouldn't be called with strings. Surface that.
+        let has_strings = !sa_owned.is_empty();
+        if has_strings && (rf.ty & FUNCADD_STRING_ARGS) == 0 {
+            return Err(format!(
+                "external '{name}' is not declared FUNCADD_STRING_ARGS but was \
+                 called with string arguments"
+            ));
+        }
+
+        // Optional output buffers.
+        let mut derivs_buf: Vec<f64> = if want_derivs {
+            vec![0.0; nr as usize]
+        } else {
+            Vec::new()
+        };
+        let hes_len = if want_hes {
+            (nr as usize) * ((nr as usize) + 1) / 2
+        } else {
+            0
+        };
+        let mut hes_buf: Vec<f64> = if want_hes { vec![0.0; hes_len] } else { Vec::new() };
+
+        // Space for a library-set error message.
+        let mut errmsg_buf: Vec<c_char> = vec![0; 1024];
+
+        // Build the arglist. Pointers into Rust-owned buffers are valid for
+        // the duration of the call since we hold those Vecs in this stack
+        // frame and the callee runs synchronously.
+        let mut al = Arglist {
+            n,
+            nr,
+            at: if at_vec.is_empty() {
+                ptr::null_mut()
+            } else {
+                at_vec.as_mut_ptr()
+            },
+            ra: if ra_vec.is_empty() {
+                ptr::null_mut()
+            } else {
+                ra_vec.as_mut_ptr()
+            },
+            sa: if sa_ptrs.is_empty() {
+                ptr::null_mut()
+            } else {
+                sa_ptrs.as_ptr() as *mut *const c_char
+            },
+            derivs: if want_derivs {
+                derivs_buf.as_mut_ptr()
+            } else {
+                ptr::null_mut()
+            },
+            hes: if want_hes {
+                hes_buf.as_mut_ptr()
+            } else {
+                ptr::null_mut()
+            },
+            dig: ptr::null_mut(),
+            funcinfo: rf.funcinfo,
+            // Some libraries read arglist.ae (e.g. to call fprintf); point at
+            // the same AmplExports we handed to funcadd_ASL.
+            ae: self._ae_ptr(),
+            f: ptr::null_mut(),
+            tva: ptr::null_mut(),
+            errmsg: errmsg_buf.as_mut_ptr(),
+            tmi: ptr::null_mut(),
+            private: ptr::null_mut(),
+            nin: 0,
+            nout: 0,
+            nsin: 0,
+            nsout: 0,
+        };
+
+        // SAFETY: rfunc is a valid extern "C" function pointer provided by
+        // the loaded library; arglist layout matches funcadd.h exactly.
+        // The AMPL lock serialises concurrent entry into the library.
+        let _guard = ampl_lock().lock().unwrap_or_else(|e| e.into_inner());
+        let value = unsafe { (rf.rfunc)(&mut al as *mut Arglist) };
+        drop(_guard);
+
+        // If the library wrote into errmsg, surface that. AMPL convention:
+        // if errmsg[0] != 0 after the call, treat as error.
+        if errmsg_buf[0] != 0 {
+            // SAFETY: errmsg_buf is a NUL-terminated C buffer (we allocated
+            // and zeroed it); the library only writes a C string there.
+            let msg = unsafe { CStr::from_ptr(errmsg_buf.as_ptr()) }
+                .to_string_lossy()
+                .into_owned();
+            return Err(format!("external '{name}' reported: {msg}"));
+        }
+
+        Ok(EvalResult {
+            value,
+            derivs: if want_derivs { Some(derivs_buf) } else { None },
+            hessian: if want_hes { Some(hes_buf) } else { None },
+        })
+    }
+
+    // Raw mutable pointer to the owned AmplExports. Used when building an
+    // arglist so the library can call back through the same table it was
+    // registered with. The Box is pinned for the lifetime of self.
+    fn _ae_ptr(&self) -> *mut AmplExports {
+        // Cast away the const; we never mutate the AmplExports ourselves.
+        (&*self._ae as *const AmplExports) as *mut AmplExports
+    }
+}
+
+/// One positional argument to an external function.
+#[derive(Debug, Clone, Copy)]
+pub enum ExternalArg<'a> {
+    Real(f64),
+    Str(&'a str),
+}
+
+/// Return value from [`ExternalLibrary::eval`].
+#[derive(Debug, Clone)]
+pub struct EvalResult {
+    /// Function value.
+    pub value: f64,
+    /// `df/dx_i` for each real argument, in `ra[]` order, if `want_derivs`.
+    pub derivs: Option<Vec<f64>>,
+    /// Packed upper-triangular Hessian in AMPL's convention,
+    /// `hes[i + j*(j+1)/2]` for `0 <= i <= j < nr`, if `want_hes`.
+    pub hessian: Option<Vec<f64>>,
+}
+
+// ---------------------------------------------------------------------------
+// Registration trampoline.
+//
+// `funcadd_ASL` can call Addfunc multiple times (once per registered name).
+// Rust closures can't be converted to `extern "C"` function pointers, so we
+// route each call through a free function that deposits into a thread-local
+// sink populated by `ExternalLibrary::load`.
+// ---------------------------------------------------------------------------
+
+thread_local! {
+    static REGISTRY_SINK: std::cell::RefCell<Option<HashMap<String, RegisteredFunc>>> =
+        std::cell::RefCell::new(None);
+}
+
+/// C-callable trampoline that receives Addfunc calls from the shared library.
+unsafe extern "C" fn trampoline_addfunc(
+    name: *const c_char,
+    f: Rfunc,
+    ty: c_int,
+    nargs: c_int,
+    funcinfo: *mut c_void,
+    _ae: *mut AmplExports,
+) {
+    if name.is_null() {
+        return;
+    }
+    // SAFETY: AMPL guarantees name is a NUL-terminated C string.
+    let cname = unsafe { CStr::from_ptr(name) };
+    let name_str = match cname.to_str() {
+        Ok(s) => s.to_owned(),
+        Err(_) => return, // non-UTF8 name — skip; real libs use ASCII.
+    };
+    REGISTRY_SINK.with(|sink| {
+        if let Some(map) = sink.borrow_mut().as_mut() {
+            map.insert(
+                name_str.clone(),
+                RegisteredFunc {
+                    name: name_str,
+                    rfunc: f,
+                    ty: ty as i32,
+                    nargs: nargs as i32,
+                    funcinfo,
+                },
+            );
+        }
+    });
+}
+
+/// Stub — some libraries ask us to register an AtReset callback. Pyomo logs a
+/// warning and does nothing. We do the same.
+unsafe extern "C" fn trampoline_atreset(
+    _ae: *mut AmplExports,
+    _f: *mut c_void,
+    _v: *mut c_void,
+) {
+    log::debug!("external library registered an AtReset callback; ignoring");
+}
+
+/// Stub — invoked by libraries that use random-valued externals. We just
+/// seed with 1 (matches Pyomo's default; no randomness in KKT paths).
+unsafe extern "C" fn trampoline_addrandinit(
+    _ae: *mut AmplExports,
+    setter: RandSeedSetter,
+    v: *mut c_void,
+) {
+    unsafe { setter(v, 1) };
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn idaes_dylib() -> Option<std::path::PathBuf> {
+        let home = std::env::var_os("HOME")?;
+        let p = std::path::PathBuf::from(home)
+            .join(".idaes/bin/general_helmholtz_external.dylib");
+        if p.exists() {
+            Some(p)
+        } else {
+            None
+        }
+    }
+
+    fn idaes_params_dir() -> Option<String> {
+        let home = std::env::var_os("HOME")?;
+        let p = std::path::PathBuf::from(home).join(
+            "Dropbox/uv/.venv/lib/python3.12/site-packages/idaes/\
+             models/properties/general_helmholtz/components/parameters/",
+        );
+        if p.exists() {
+            p.to_str().map(|s| s.to_owned())
+        } else {
+            None
+        }
+    }
+
+    /// Opening the IDAES Helmholtz dylib (when present locally) should
+    /// surface the three functions used by the issue #15 fixture.
+    #[test]
+    fn load_idaes_helmholtz_dylib_registers_known_functions() {
+        let Some(path) = idaes_dylib() else {
+            eprintln!("skipping: IDAES dylib not present");
+            return;
+        };
+
+        let lib = ExternalLibrary::load(&path).expect("load should succeed");
+        let names: Vec<String> = lib.function_names().map(|s| s.to_owned()).collect();
+
+        for required in &["vf_hp", "h_liq_hp", "h_vap_hp"] {
+            assert!(
+                names.iter().any(|n| n == required),
+                "expected {required} in registered names: {names:?}"
+            );
+        }
+    }
+
+    /// Evaluate vf_hp at the NL fixture's initial guess. We don't assert the
+    /// exact numeric value (that's an IDAES invariant, not a ripopt one), but
+    /// the return value must be finite and the call must not set errmsg.
+    #[test]
+    fn eval_vf_hp_at_fixture_initial_point() {
+        let Some(path) = idaes_dylib() else {
+            eprintln!("skipping: IDAES dylib not present");
+            return;
+        };
+        let Some(params_dir) = idaes_params_dir() else {
+            eprintln!("skipping: IDAES parameters directory not present");
+            return;
+        };
+
+        let lib = ExternalLibrary::load(&path).expect("load");
+        // Fixture initial guess: h = 1878.71 kJ/kg-scaled, p = 101.325 kPa
+        // (the scaled values actually passed through the v3/v4 slots are
+        // 1878.71 * 0.0555... and 101325 * 0.001 respectively; using raw
+        // values here, the function should still return a finite number).
+        let args = [
+            ExternalArg::Str("h2o"),
+            ExternalArg::Real(1878.71 * 0.055508472036052976),
+            ExternalArg::Real(101325.0 * 0.001),
+            ExternalArg::Str(&params_dir),
+        ];
+        let res = lib.eval("vf_hp", &args, false, false).expect("eval");
+        assert!(
+            res.value.is_finite(),
+            "vf_hp returned non-finite value {}",
+            res.value
+        );
+    }
+
+    /// Same call path, but asking for first derivatives. derivs must be a
+    /// length-2 buffer (nr=2) of finite values.
+    #[test]
+    fn eval_vf_hp_with_derivatives() {
+        let Some(path) = idaes_dylib() else {
+            eprintln!("skipping: IDAES dylib not present");
+            return;
+        };
+        let Some(params_dir) = idaes_params_dir() else {
+            eprintln!("skipping: IDAES parameters directory not present");
+            return;
+        };
+
+        let lib = ExternalLibrary::load(&path).expect("load");
+        let args = [
+            ExternalArg::Str("h2o"),
+            ExternalArg::Real(1878.71 * 0.055508472036052976),
+            ExternalArg::Real(101325.0 * 0.001),
+            ExternalArg::Str(&params_dir),
+        ];
+        let res = lib.eval("vf_hp", &args, true, false).expect("eval");
+        let derivs = res.derivs.expect("derivs requested");
+        assert_eq!(derivs.len(), 2, "nr=2 reals -> 2 derivatives");
+        for (i, d) in derivs.iter().enumerate() {
+            assert!(d.is_finite(), "derivs[{i}] = {d} not finite");
+        }
+    }
+
+    /// Also request the packed Hessian. For nr=2 reals, that's 3 entries
+    /// (H00, H01, H11) in AMPL's packed upper-triangular layout.
+    #[test]
+    fn eval_vf_hp_with_hessian() {
+        let Some(path) = idaes_dylib() else {
+            eprintln!("skipping: IDAES dylib not present");
+            return;
+        };
+        let Some(params_dir) = idaes_params_dir() else {
+            eprintln!("skipping: IDAES parameters directory not present");
+            return;
+        };
+
+        let lib = ExternalLibrary::load(&path).expect("load");
+        let args = [
+            ExternalArg::Str("h2o"),
+            ExternalArg::Real(1878.71 * 0.055508472036052976),
+            ExternalArg::Real(101325.0 * 0.001),
+            ExternalArg::Str(&params_dir),
+        ];
+        let res = lib.eval("vf_hp", &args, true, true).expect("eval");
+        let hes = res.hessian.expect("hessian requested");
+        assert_eq!(hes.len(), 3, "nr=2 -> packed Hessian of length 3");
+        for (i, h) in hes.iter().enumerate() {
+            assert!(h.is_finite(), "hes[{i}] = {h} not finite");
+        }
+    }
+}

--- a/src/nl/header.rs
+++ b/src/nl/header.rs
@@ -18,6 +18,8 @@ pub struct NlHeader {
     pub common_expr_counts: [usize; 5],
     pub nnz_jac: usize,
     pub nnz_grad: usize,
+    /// Number of AMPL imported (external) functions declared in the file.
+    pub n_funcs: usize,
 }
 
 impl NlHeader {
@@ -68,6 +70,8 @@ pub fn parse_header<'a>(lines: &mut impl Iterator<Item = &'a str>) -> Result<NlH
         common_expr_counts: [get(8, 0), get(8, 1), get(8, 2), get(8, 3), get(8, 4)],
         nnz_jac: get(6, 0),
         nnz_grad: get(6, 1),
+        // Line 4 (0-indexed dim line): `nwv nfunc arith flags`.
+        n_funcs: get(4, 1),
     })
 }
 

--- a/src/nl/mod.rs
+++ b/src/nl/mod.rs
@@ -1,5 +1,6 @@
 pub mod autodiff;
 pub mod expr;
+pub mod external;
 pub mod header;
 pub mod parser;
 pub mod problem_impl;

--- a/src/nl/parser.rs
+++ b/src/nl/parser.rs
@@ -1,6 +1,18 @@
 use super::expr::{self, ExprNode};
 use super::header::{self, NlHeader};
 
+/// AMPL imported (external) function declaration from an `F` segment.
+#[derive(Debug, Clone)]
+pub struct ImportedFunc {
+    pub id: usize,
+    /// 0 = real-valued, 1 = string-valued (per AMPL's funcadd ABI).
+    pub kind: usize,
+    /// Declared number of arguments (may be -1 for variable-arity in the spec;
+    /// we store the raw decoded value as read).
+    pub nargs: i64,
+    pub name: String,
+}
+
 /// Raw parsed data from an NL file.
 #[derive(Debug)]
 pub struct NlFileData {
@@ -28,6 +40,8 @@ pub struct NlFileData {
     pub y0: Vec<f64>,
     /// Jacobian column pointers (cumulative), from k segment.
     pub jac_col_ptrs: Vec<usize>,
+    /// AMPL imported functions declared via `F` segments.
+    pub imported_funcs: Vec<ImportedFunc>,
 }
 
 /// Parse an NL file from its text content.
@@ -52,6 +66,7 @@ pub fn parse_nl_file(content: &str) -> Result<NlFileData, String> {
         x0: vec![0.0; n],
         y0: vec![0.0; m],
         jac_col_ptrs: Vec::new(),
+        imported_funcs: Vec::new(),
         header,
     };
 
@@ -343,6 +358,28 @@ pub fn parse_nl_file(content: &str) -> Result<NlFileData, String> {
                 let count = parse_segment_count_after_space(line)?;
                 pos += 1 + count;
             }
+            b'F' => {
+                // AMPL imported (external) function declaration:
+                // `F<k> <type> <nargs> <name>` — all on one line.
+                let parts: Vec<&str> = line.split_whitespace().collect();
+                let id = parse_segment_index(parts[0], 'F')?;
+                let kind: usize = parts
+                    .get(1)
+                    .and_then(|s| s.parse().ok())
+                    .unwrap_or(0);
+                let nargs: i64 = parts
+                    .get(2)
+                    .and_then(|s| s.parse().ok())
+                    .unwrap_or(0);
+                let name = parts.get(3).copied().unwrap_or("").to_string();
+                data.imported_funcs.push(ImportedFunc {
+                    id,
+                    kind,
+                    nargs,
+                    name,
+                });
+                pos += 1;
+            }
             _ => {
                 pos += 1;
             }
@@ -426,6 +463,15 @@ fn count_expr_lines_recursive(lines: &[&str], pos: &mut usize) {
 
     if token.starts_with('n') || token.starts_with('v') || token.starts_with('h') {
         // Leaf node: 1 line
+    } else if token.starts_with('f') {
+        // Funcall: `f<id> <nargs>` on the current line, then nargs sub-expressions.
+        let rest = &token[1..];
+        let mut parts = rest.split_whitespace();
+        let _id = parts.next().unwrap_or("0");
+        let nargs: usize = parts.next().unwrap_or("0").parse().unwrap_or(0);
+        for _ in 0..nargs {
+            count_expr_lines_recursive(lines, pos);
+        }
     } else if token.starts_with('o') {
         let opcode: usize = token[1..].parse().unwrap_or(0);
         match opcode {

--- a/src/nl/problem_impl.rs
+++ b/src/nl/problem_impl.rs
@@ -1,7 +1,8 @@
 use std::collections::HashMap;
 
 use super::autodiff::Tape;
-use super::parser::NlFileData;
+use super::expr::ExprNode;
+use super::parser::{ImportedFunc, NlFileData};
 use crate::NlpProblem;
 
 /// An NLP problem parsed from an NL file, implementing the NlpProblem trait.
@@ -40,7 +41,18 @@ pub struct NlProblem {
 
 impl NlProblem {
     /// Build an NlProblem from parsed NL file data.
-    pub fn from_nl_data(data: NlFileData) -> Self {
+    ///
+    /// Returns an error if the problem uses AMPL imported (external) functions —
+    /// these reference compiled C routines via AMPL's `funcadd` ABI and are not
+    /// yet supported by ripopt.
+    pub fn from_nl_data(data: NlFileData) -> Result<Self, String> {
+        if let Some(name) = find_external_func(&data) {
+            return Err(format!(
+                "problem uses external function '{}'; external functions \
+                 (AMPL imported functions) are not supported by ripopt",
+                name
+            ));
+        }
         let n = data.header.n_vars;
         let m = data.header.n_constrs;
 
@@ -148,7 +160,7 @@ impl NlProblem {
             hess_map.insert((r, c), idx);
         }
 
-        NlProblem {
+        Ok(NlProblem {
             n,
             m,
             x_l: data.x_l,
@@ -167,7 +179,7 @@ impl NlProblem {
             hess_rows,
             hess_cols,
             hess_map,
-        }
+        })
     }
 
     /// Compute the gradient of the objective (nonlinear + linear).
@@ -326,5 +338,65 @@ impl NlpProblem for NlProblem {
             }
         }
         true
+    }
+}
+
+/// Scan parsed NL data for any `ExprNode::Funcall`. If found, return a
+/// human-readable function name (resolved from the F-segment declarations
+/// when possible) so callers can raise a clear error.
+fn find_external_func(data: &NlFileData) -> Option<String> {
+    let mut found: Option<usize> = None;
+    if let Some((_, _, Some(expr))) = data.obj_exprs.first() {
+        walk_for_funcall(expr, &mut found);
+    }
+    if found.is_none() {
+        for expr in data.con_exprs.iter().flatten() {
+            walk_for_funcall(expr, &mut found);
+            if found.is_some() {
+                break;
+            }
+        }
+    }
+    if found.is_none() {
+        for expr in &data.common_exprs {
+            walk_for_funcall(expr, &mut found);
+            if found.is_some() {
+                break;
+            }
+        }
+    }
+    let id = found?;
+    let name = data
+        .imported_funcs
+        .iter()
+        .find(|f: &&ImportedFunc| f.id == id)
+        .map(|f| f.name.clone())
+        .filter(|n| !n.is_empty())
+        .unwrap_or_else(|| format!("f{}", id));
+    Some(name)
+}
+
+fn walk_for_funcall(expr: &ExprNode, found: &mut Option<usize>) {
+    if found.is_some() {
+        return;
+    }
+    match expr {
+        ExprNode::Funcall { id, .. } => *found = Some(*id),
+        ExprNode::Const(_) | ExprNode::Var(_) | ExprNode::StringLiteral(_) => {}
+        ExprNode::Binary(_, l, r) => {
+            walk_for_funcall(l, found);
+            walk_for_funcall(r, found);
+        }
+        ExprNode::Unary(_, a) => walk_for_funcall(a, found),
+        ExprNode::Nary(_, args) => {
+            for a in args {
+                walk_for_funcall(a, found);
+            }
+        }
+        ExprNode::If(c, t, e) => {
+            walk_for_funcall(c, found);
+            walk_for_funcall(t, found);
+            walk_for_funcall(e, found);
+        }
     }
 }

--- a/src/nl/problem_impl.rs
+++ b/src/nl/problem_impl.rs
@@ -1,7 +1,9 @@
-use std::collections::HashMap;
+use std::collections::{HashMap, HashSet};
+use std::sync::Arc;
 
-use super::autodiff::Tape;
+use super::autodiff::{ExternalResolver, Tape};
 use super::expr::ExprNode;
+use super::external::ExternalLibrary;
 use super::parser::{ImportedFunc, NlFileData};
 use crate::NlpProblem;
 
@@ -42,17 +44,15 @@ pub struct NlProblem {
 impl NlProblem {
     /// Build an NlProblem from parsed NL file data.
     ///
-    /// Returns an error if the problem uses AMPL imported (external) functions —
-    /// these reference compiled C routines via AMPL's `funcadd` ABI and are not
-    /// yet supported by ripopt.
+    /// If the problem uses AMPL imported (external) functions, the libraries
+    /// listed in the `AMPLFUNC` environment variable are loaded via
+    /// [`ExternalLibrary`] and each declared `F` segment is resolved against
+    /// the union of their registered functions. An error is returned if any
+    /// function cannot be resolved.
     pub fn from_nl_data(data: NlFileData) -> Result<Self, String> {
-        if let Some(name) = find_external_func(&data) {
-            return Err(format!(
-                "problem uses external function '{}'; external functions \
-                 (AMPL imported functions) are not supported by ripopt",
-                name
-            ));
-        }
+        // Phase-2: build a resolver mapping each Funcall id -> (library, name).
+        let resolver = resolve_externals(&data)?;
+
         let n = data.header.n_vars;
         let m = data.header.n_constrs;
 
@@ -65,9 +65,11 @@ impl NlProblem {
 
         // Pre-build common expression tapes to avoid exponential inlining blowup
         use super::autodiff::CommonExprCache;
-        let ce_cache = CommonExprCache::build(&data.common_exprs, n);
+        let ce_cache = CommonExprCache::build_with_externals(&data.common_exprs, n, &resolver);
 
-        let obj_tape = obj_expr.map(|expr| Tape::build_cached(&expr, &data.common_exprs, n, &ce_cache));
+        let obj_tape = obj_expr.map(|expr| {
+            Tape::build_cached_with_externals(&expr, &data.common_exprs, n, &ce_cache, &resolver)
+        });
 
         let obj_linear = if obj_idx < data.obj_linear.len() {
             data.obj_linear[obj_idx].clone()
@@ -79,7 +81,17 @@ impl NlProblem {
         let con_tapes: Vec<Option<Tape>> = data
             .con_exprs
             .iter()
-            .map(|expr| expr.as_ref().map(|e| Tape::build_cached(e, &data.common_exprs, n, &ce_cache)))
+            .map(|expr| {
+                expr.as_ref().map(|e| {
+                    Tape::build_cached_with_externals(
+                        e,
+                        &data.common_exprs,
+                        n,
+                        &ce_cache,
+                        &resolver,
+                    )
+                })
+            })
             .collect();
 
         // Build Jacobian sparsity from con_linear entries + nonlinear variables
@@ -341,62 +353,129 @@ impl NlpProblem for NlProblem {
     }
 }
 
-/// Scan parsed NL data for any `ExprNode::Funcall`. If found, return a
-/// human-readable function name (resolved from the F-segment declarations
-/// when possible) so callers can raise a clear error.
-fn find_external_func(data: &NlFileData) -> Option<String> {
-    let mut found: Option<usize> = None;
+/// Collect the set of `Funcall` ids referenced anywhere in the NL data
+/// (objective, constraints, common subexpressions).
+fn collect_funcall_ids(data: &NlFileData) -> HashSet<usize> {
+    let mut ids: HashSet<usize> = HashSet::new();
     if let Some((_, _, Some(expr))) = data.obj_exprs.first() {
-        walk_for_funcall(expr, &mut found);
+        walk_collect_ids(expr, &mut ids);
     }
-    if found.is_none() {
-        for expr in data.con_exprs.iter().flatten() {
-            walk_for_funcall(expr, &mut found);
-            if found.is_some() {
-                break;
-            }
-        }
+    for expr in data.con_exprs.iter().flatten() {
+        walk_collect_ids(expr, &mut ids);
     }
-    if found.is_none() {
-        for expr in &data.common_exprs {
-            walk_for_funcall(expr, &mut found);
-            if found.is_some() {
-                break;
-            }
-        }
+    for expr in &data.common_exprs {
+        walk_collect_ids(expr, &mut ids);
     }
-    let id = found?;
-    let name = data
-        .imported_funcs
-        .iter()
-        .find(|f: &&ImportedFunc| f.id == id)
-        .map(|f| f.name.clone())
-        .filter(|n| !n.is_empty())
-        .unwrap_or_else(|| format!("f{}", id));
-    Some(name)
+    ids
 }
 
-fn walk_for_funcall(expr: &ExprNode, found: &mut Option<usize>) {
-    if found.is_some() {
-        return;
-    }
+fn walk_collect_ids(expr: &ExprNode, ids: &mut HashSet<usize>) {
     match expr {
-        ExprNode::Funcall { id, .. } => *found = Some(*id),
+        ExprNode::Funcall { id, args } => {
+            ids.insert(*id);
+            for a in args {
+                walk_collect_ids(a, ids);
+            }
+        }
         ExprNode::Const(_) | ExprNode::Var(_) | ExprNode::StringLiteral(_) => {}
         ExprNode::Binary(_, l, r) => {
-            walk_for_funcall(l, found);
-            walk_for_funcall(r, found);
+            walk_collect_ids(l, ids);
+            walk_collect_ids(r, ids);
         }
-        ExprNode::Unary(_, a) => walk_for_funcall(a, found),
+        ExprNode::Unary(_, a) => walk_collect_ids(a, ids),
         ExprNode::Nary(_, args) => {
             for a in args {
-                walk_for_funcall(a, found);
+                walk_collect_ids(a, ids);
             }
         }
         ExprNode::If(c, t, e) => {
-            walk_for_funcall(c, found);
-            walk_for_funcall(t, found);
-            walk_for_funcall(e, found);
+            walk_collect_ids(c, ids);
+            walk_collect_ids(t, ids);
+            walk_collect_ids(e, ids);
         }
     }
+}
+
+/// Split the `AMPLFUNC` environment variable into candidate library paths.
+/// AMPL accepts either newline- or (on UNIX) colon-separated lists.
+fn amplfunc_paths() -> Vec<std::path::PathBuf> {
+    match std::env::var("AMPLFUNC") {
+        Err(_) => Vec::new(),
+        Ok(s) => s
+            .split(|c: char| c == '\n' || c == ':')
+            .map(str::trim)
+            .filter(|s| !s.is_empty())
+            .map(std::path::PathBuf::from)
+            .collect(),
+    }
+}
+
+/// Build the tape builder's [`ExternalResolver`] by:
+///   1. collecting every `Funcall` id referenced in the NL data,
+///   2. loading every shared library listed in `AMPLFUNC`,
+///   3. for each imported F-segment, looking up a library that registered
+///      a function by the declared name.
+/// Returns the resolver, or a `String` error describing what's missing.
+fn resolve_externals(data: &NlFileData) -> Result<ExternalResolver, String> {
+    let used_ids = collect_funcall_ids(data);
+    if used_ids.is_empty() {
+        return Ok(ExternalResolver::default());
+    }
+
+    // Load every library listed in AMPLFUNC. Keep the Arc handles so later
+    // lookups succeed and so the libraries stay alive with each tape.
+    let lib_paths = amplfunc_paths();
+    if lib_paths.is_empty() {
+        let first_name = data
+            .imported_funcs
+            .iter()
+            .find(|f: &&ImportedFunc| used_ids.contains(&f.id))
+            .map(|f| f.name.clone())
+            .unwrap_or_else(|| "<unknown>".to_string());
+        return Err(format!(
+            "problem uses external function '{first_name}' but AMPLFUNC is not set. \
+             Set AMPLFUNC to a newline- or colon-separated list of shared-library paths \
+             (e.g. the IDAES Helmholtz extension)."
+        ));
+    }
+
+    let mut libs: Vec<Arc<ExternalLibrary>> = Vec::with_capacity(lib_paths.len());
+    for path in &lib_paths {
+        let lib = ExternalLibrary::load(path).map_err(|e| {
+            format!("failed to load AMPLFUNC library '{}': {}", path.display(), e)
+        })?;
+        libs.push(Arc::new(lib));
+    }
+
+    // Resolve each referenced F-segment against the loaded libraries.
+    let mut funcs_by_id: HashMap<usize, (Arc<ExternalLibrary>, String)> = HashMap::new();
+    for id in &used_ids {
+        let func = data
+            .imported_funcs
+            .iter()
+            .find(|f: &&ImportedFunc| f.id == *id)
+            .ok_or_else(|| {
+                format!("problem references Funcall id={id} but no F-segment declares it")
+            })?;
+        let name = func.name.clone();
+        let matching = libs.iter().find(|lib| lib.get(&name).is_some());
+        match matching {
+            Some(lib) => {
+                funcs_by_id.insert(*id, (lib.clone(), name));
+            }
+            None => {
+                let loaded: Vec<String> = lib_paths
+                    .iter()
+                    .map(|p| p.display().to_string())
+                    .collect();
+                return Err(format!(
+                    "external function '{name}' (F{id}) was not registered by any \
+                     AMPLFUNC library; loaded: [{}]",
+                    loaded.join(", ")
+                ));
+            }
+        }
+    }
+
+    Ok(ExternalResolver { funcs_by_id })
 }

--- a/tests/fixtures/issue_15/generate_helmholtz_nl.py
+++ b/tests/fixtures/issue_15/generate_helmholtz_nl.py
@@ -1,0 +1,90 @@
+"""Generate the IDAES Helmholtz external-function NL fixture for issue #15.
+
+Original script written with GPT 5.4 and validated locally by CMarcher on
+https://github.com/jkitchin/ripopt/issues/15. Saved here so the fixture can
+be regenerated whenever IDAES + the general_helmholtz_external shared library
+are available.
+
+Running the script:
+    python tests/fixtures/issue_15/generate_helmholtz_nl.py
+
+Requires IDAES 2.x with `idaes get-extensions` already run so that
+`~/.idaes/bin/general_helmholtz_external.{dylib,so,dll}` exists. Writes the
+`.nl` file to tests/fixtures/issue_15/idaes_helmholtz.nl.
+"""
+
+from pathlib import Path
+import shutil
+
+import idaes
+from idaes.core import FlowsheetBlock
+from idaes.models.properties.general_helmholtz import (
+    HelmholtzParameterBlock,
+    PhaseType,
+    StateVars,
+    AmountBasis,
+)
+from idaes.models.unit_models.heater import Heater
+from idaes.core.util.model_statistics import degrees_of_freedom
+from pyomo.environ import ConcreteModel, SolverFactory, assert_optimal_termination, value
+
+
+FIXTURE_NL = Path(__file__).with_name("idaes_helmholtz.nl")
+
+
+def build_model():
+    m = ConcreteModel()
+    m.fs = FlowsheetBlock(dynamic=False)
+    m.fs.properties = HelmholtzParameterBlock(
+        pure_component="h2o",
+        phase_presentation=PhaseType.LG,
+        state_vars=StateVars.PH,
+        amount_basis=AmountBasis.MOLE,
+    )
+
+    m.fs.heater = Heater(property_package=m.fs.properties)
+    m.fs.heater.heat_duty.fix(0)
+    m.fs.heater.inlet.flow_mol.fix(1)
+    m.fs.heater.inlet.enth_mol.fix(1878.71)
+    m.fs.heater.inlet.pressure.fix(101325)
+    return m
+
+
+def solve_with_ipopt(model):
+    ipopt_path = Path(idaes.bin_directory) / "ipopt"
+    if not ipopt_path.exists():
+        raise FileNotFoundError(f"Expected ipopt at {ipopt_path}")
+
+    solver = SolverFactory("ipopt", executable=str(ipopt_path))
+    results = solver.solve(
+        model,
+        tee=False,
+        keepfiles=True,
+        symbolic_solver_labels=True,
+    )
+    assert_optimal_termination(results)
+
+    nl_source = Path(solver._problem_files[0])
+    shutil.copy2(nl_source, FIXTURE_NL)
+    return nl_source
+
+
+def main():
+    model = build_model()
+    dof = degrees_of_freedom(model)
+    if dof != 0:
+        raise AssertionError(f"Expected 0 degrees of freedom, got {dof}")
+
+    model.fs.heater.initialize()
+    nl_source = solve_with_ipopt(model)
+
+    outlet_temp = value(model.fs.heater.control_volume.properties_out[0].temperature)
+    if abs(outlet_temp - 298.0) > 1e-2:
+        raise AssertionError(f"Unexpected outlet temperature: {outlet_temp}")
+
+    print(f"IPOPT_NL_SOURCE={nl_source}")
+    print(f"FIXTURE_NL={FIXTURE_NL}")
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/fixtures/issue_15/idaes_helmholtz.nl
+++ b/tests/fixtures/issue_15/idaes_helmholtz.nl
@@ -1,0 +1,109 @@
+g3 1 1 0	# problem unknown
+ 3 3 0 0 3 	# vars, constraints, objectives, ranges, eqns
+ 2 0 0 0 0 0	# nonlinear constrs, objs; ccons: lin, nonlin, nd, nzlb
+ 0 0	# network constraints: nonlinear, linear
+ 3 0 0 	# nonlinear vars in constraints, objectives, both
+ 0 3 0 1	# linear network variables; functions; arith, flags
+ 0 0 0 0 0 	# discrete variables: binary, integer, nonlinear (b,c,o)
+ 7 0 	# nonzeros in Jacobian, obj. gradient
+ 51 53	# max name lengths: constraints, variables
+ 0 5 0 6 0	# common exprs: b,c,o,c1,o1
+F0 1 -1 vf_hp
+F1 1 -1 h_liq_hp
+F2 1 -1 h_vap_hp
+V3 1 0	#fs.heater.control_volume.properties_out[0.0].h_kJ_per_kg
+1 0.055508472036052976
+n0
+V4 1 0	#fs.heater.control_volume.properties_out[0.0].p_kPa
+2 0.001
+n0
+V5 0 0	#fs.heater.control_volume.properties_out[0.0].vapor_frac
+f0 4	#vf_hp_func
+h3:h2o
+v3	#fs.heater.control_volume.properties_out[0.0].h_kJ_per_kg
+v4	#fs.heater.control_volume.properties_out[0.0].p_kPa
+h126:/Users/jkitchin/Dropbox/uv/.venv/lib/python3.12/site-packages/idaes/models/properties/general_helmholtz/components/parameters/
+V6 0 0	#fs.heater.control_volume.properties_out[0.0].phase_frac[Liq]
+o0	#+
+o16	#-
+v5	#fs.heater.control_volume.properties_out[0.0].vapor_frac
+n1.0
+V7 0 0	#fs.heater.control_volume.properties_out[0.0].phase_frac[Vap]
+f0 4	#vf_hp_func
+h3:h2o
+v3	#fs.heater.control_volume.properties_out[0.0].h_kJ_per_kg
+v4	#fs.heater.control_volume.properties_out[0.0].p_kPa
+h126:/Users/jkitchin/Dropbox/uv/.venv/lib/python3.12/site-packages/idaes/models/properties/general_helmholtz/components/parameters/
+V8 0 1	#fs.heater.control_volume.properties_out[0.0].material_flow_terms[Liq]
+o2	#*
+v0	#fs.heater.control_volume.properties_out[0.0].flow_mol
+v6	#fs.heater.control_volume.properties_out[0.0].phase_frac[Liq]
+V9 0 1	#fs.heater.control_volume.properties_out[0.0].material_flow_terms[Vap]
+o2	#*
+v0	#fs.heater.control_volume.properties_out[0.0].flow_mol
+v7	#fs.heater.control_volume.properties_out[0.0].phase_frac[Vap]
+C0	#fs.heater.control_volume.material_balances[0.0,h2o]
+o16	#-
+o0	#+
+v8	#fs.heater.control_volume.properties_out[0.0].material_flow_terms[Liq]
+v9	#fs.heater.control_volume.properties_out[0.0].material_flow_terms[Vap]
+V10 0 2	#fs.heater.control_volume.properties_out[0.0].enth_mol_phase[Liq]
+o2	#*
+n18.015268000000003
+f1 4	#h_liq_hp_func
+h3:h2o
+v3	#fs.heater.control_volume.properties_out[0.0].h_kJ_per_kg
+v4	#fs.heater.control_volume.properties_out[0.0].p_kPa
+h126:/Users/jkitchin/Dropbox/uv/.venv/lib/python3.12/site-packages/idaes/models/properties/general_helmholtz/components/parameters/
+V11 0 2	#fs.heater.control_volume.properties_out[0.0].enthalpy_flow_terms[Liq]
+o2	#*
+o2	#*
+v10	#fs.heater.control_volume.properties_out[0.0].enth_mol_phase[Liq]
+v6	#fs.heater.control_volume.properties_out[0.0].phase_frac[Liq]
+v0	#fs.heater.control_volume.properties_out[0.0].flow_mol
+V12 0 2	#fs.heater.control_volume.properties_out[0.0].enth_mol_phase[Vap]
+o2	#*
+n18.015268000000003
+f2 4	#h_vap_hp_func
+h3:h2o
+v3	#fs.heater.control_volume.properties_out[0.0].h_kJ_per_kg
+v4	#fs.heater.control_volume.properties_out[0.0].p_kPa
+h126:/Users/jkitchin/Dropbox/uv/.venv/lib/python3.12/site-packages/idaes/models/properties/general_helmholtz/components/parameters/
+V13 0 2	#fs.heater.control_volume.properties_out[0.0].enthalpy_flow_terms[Vap]
+o2	#*
+o2	#*
+v12	#fs.heater.control_volume.properties_out[0.0].enth_mol_phase[Vap]
+v7	#fs.heater.control_volume.properties_out[0.0].phase_frac[Vap]
+v0	#fs.heater.control_volume.properties_out[0.0].flow_mol
+C1	#fs.heater.control_volume.enthalpy_balances[0.0]
+o16	#-
+o0	#+
+v11	#fs.heater.control_volume.properties_out[0.0].enthalpy_flow_terms[Liq]
+v13	#fs.heater.control_volume.properties_out[0.0].enthalpy_flow_terms[Vap]
+C2	#fs.heater.control_volume.pressure_balance[0.0]
+n0
+x3	# initial guess
+0 1.0	#fs.heater.control_volume.properties_out[0.0].flow_mol
+1 1878.71	#fs.heater.control_volume.properties_out[0.0].enth_mol
+2 101325.0	#fs.heater.control_volume.properties_out[0.0].pressure
+r	#3 ranges (rhs's)
+4 -1.0	#fs.heater.control_volume.material_balances[0.0,h2o]
+4 -1878.7099999999614	#fs.heater.control_volume.enthalpy_balances[0.0]
+4 -101325	#fs.heater.control_volume.pressure_balance[0.0]
+b	#3 bounds (on variables)
+3	#fs.heater.control_volume.properties_out[0.0].flow_mol
+0 0.011021386931383999 80765.34157807355	#fs.heater.control_volume.properties_out[0.0].enth_mol
+0 1.0000000000000002e-06 1100000000.0	#fs.heater.control_volume.properties_out[0.0].pressure
+k2	#intermediate Jacobian column lengths
+2
+4
+J0 3	#fs.heater.control_volume.material_balances[0.0,h2o]
+0 0
+1 0
+2 0
+J1 3	#fs.heater.control_volume.enthalpy_balances[0.0]
+0 0
+1 0
+2 0
+J2 1	#fs.heater.control_volume.pressure_balance[0.0]
+2 -1

--- a/tests/nl_integration.rs
+++ b/tests/nl_integration.rs
@@ -268,7 +268,7 @@ x2
 1 2
 ";
     let data = parse_nl_file(nl).expect("parse failed");
-    let problem = NlProblem::from_nl_data(data);
+    let problem = NlProblem::from_nl_data(data).expect("build failed");
 
     // Evaluate objective at initial point x=(1,2)
     let x = vec![1.0, 2.0];
@@ -318,7 +318,7 @@ x3
 2 3
 ";
     let data = parse_nl_file(nl).expect("parse failed");
-    let problem = NlProblem::from_nl_data(data);
+    let problem = NlProblem::from_nl_data(data).expect("build failed");
 
     let x = vec![1.0, 2.0, 3.0];
     let mut f = 0.0; problem.objective(&x, true, &mut f);
@@ -373,7 +373,7 @@ x2
 1 1
 ";
     let data = parse_nl_file(nl).expect("parse failed");
-    let problem = NlProblem::from_nl_data(data);
+    let problem = NlProblem::from_nl_data(data).expect("build failed");
     let result = solve_nl(&problem);
 
     assert_eq!(
@@ -440,5 +440,140 @@ fn nl_sol_writer() {
     assert!(
         output.contains("\n1\n"),
         "SOL should contain constraint count"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// External (AMPL imported) functions (issue #15)
+// ---------------------------------------------------------------------------
+
+/// Parser must accept NL files with F segments and `f<id> <nargs>` expressions
+/// without raising "Unknown expression token". Solve-time construction must
+/// reject the problem with a clear, named error referring to the function.
+#[test]
+fn nl_parse_external_function_reports_clean_error() {
+    // Problem:
+    //   minimize myfunc(x0)
+    //   s.t.     x0 >= 0
+    // Header carries nfunc=1 on dim line 4 (field 1). The F0 segment declares
+    // `myfunc` as a real-valued (type 0) one-argument function. The objective
+    // uses the `f0 1` call with a single argument v0.
+    let nl = "\
+g3 1 1 0
+ 1 0 1 0 0
+ 0 1
+ 0 0
+ 1 0 1
+ 0 1 0 0
+ 0 0 0 0 0
+ 0 1
+ 0 0
+ 0 0 0 0 0
+F0 0 1 myfunc
+O0 0
+f0 1
+v0
+b
+2 0.0
+k0
+G0 1
+0 0
+x1
+0 1
+";
+    let data = parse_nl_file(nl).expect("parse should succeed with f/F tokens");
+    assert_eq!(data.imported_funcs.len(), 1);
+    assert_eq!(data.imported_funcs[0].id, 0);
+    assert_eq!(data.imported_funcs[0].name, "myfunc");
+    assert_eq!(data.header.n_funcs, 1);
+
+    let err = NlProblem::from_nl_data(data)
+        .err()
+        .expect("from_nl_data should reject external functions");
+    assert!(
+        err.contains("myfunc") && err.contains("external function"),
+        "error should name the function and mention external functions, got: {err}"
+    );
+}
+
+/// Regression fixture: the real `.nl` file produced by the IDAES Helmholtz
+/// example in issue #15 (CMarcher). Before this patch the parser failed with
+/// `Unknown expression token: 'f0 4'`; now the parser must accept all three
+/// `F`-segment declarations and the `f<id> <nargs>` calls, and construction
+/// must reject the problem with a clear, named error.
+#[test]
+fn nl_parse_idaes_helmholtz_fixture() {
+    let nl = include_str!("fixtures/issue_15/idaes_helmholtz.nl");
+    let data = parse_nl_file(nl).expect("IDAES fixture should parse without Unknown token error");
+
+    // Header carries three imported functions (see dim line 4 of the fixture).
+    assert_eq!(data.header.n_funcs, 3, "expected nfunc=3");
+    assert_eq!(data.imported_funcs.len(), 3);
+    let names: Vec<String> = data
+        .imported_funcs
+        .iter()
+        .map(|f| f.name.clone())
+        .collect();
+    assert!(names.iter().any(|n| n == "vf_hp"), "expected vf_hp in {names:?}");
+    assert!(names.iter().any(|n| n == "h_liq_hp"), "expected h_liq_hp in {names:?}");
+    assert!(names.iter().any(|n| n == "h_vap_hp"), "expected h_vap_hp in {names:?}");
+
+    let err = NlProblem::from_nl_data(data)
+        .err()
+        .expect("IDAES Helmholtz problem must be rejected at construction");
+    assert!(
+        err.contains("external function"),
+        "error should mention external functions, got: {err}"
+    );
+    // The first Funcall encountered in the objective/constraints references
+    // one of the declared names.
+    assert!(
+        names.iter().any(|n| err.contains(n)),
+        "error should name one of the imported functions, got: {err}"
+    );
+}
+
+/// When the same `f<id>` token appears in a constraint, the error should
+/// still surface — not a parse failure on the token.
+#[test]
+fn nl_parse_external_function_in_constraint() {
+    // Problem:
+    //   minimize x0
+    //   s.t.     g(x0) == 0   with g(.) = myfunc(.)
+    let nl = "\
+g3 1 1 0
+ 1 1 1 0 1
+ 1 1
+ 0 0
+ 1 1 1
+ 0 1 0 0
+ 0 0 0 0 0
+ 1 1
+ 0 0
+ 0 0 0 0 0
+F0 0 1 myfunc
+C0
+f0 1
+v0
+O0 0
+n0
+r
+4 0
+b
+3
+k0
+0
+J0 1
+0 1
+G0 1
+0 1
+x1
+0 1
+";
+    let data = parse_nl_file(nl).expect("parse should succeed");
+    let err = NlProblem::from_nl_data(data).err().expect("should reject");
+    assert!(
+        err.contains("myfunc"),
+        "error should name the function, got: {err}"
     );
 }

--- a/tests/nl_integration.rs
+++ b/tests/nl_integration.rs
@@ -1,6 +1,13 @@
 use ripopt::nl::{parse_nl_file, NlProblem, write_sol};
 use ripopt::{NlpProblem, SolveResult, SolveStatus, SolverOptions};
 
+/// Shared lock for tests that mutate process-global env vars (AMPLFUNC).
+/// Tests that would otherwise race for that state take this lock first.
+fn env_lock() -> &'static std::sync::Mutex<()> {
+    static LOCK: std::sync::OnceLock<std::sync::Mutex<()>> = std::sync::OnceLock::new();
+    LOCK.get_or_init(|| std::sync::Mutex::new(()))
+}
+
 /// Helper: solve an NlProblem with default options (quiet).
 fn solve_nl(problem: &NlProblem) -> SolveResult {
     let mut opts = SolverOptions::default();
@@ -518,19 +525,64 @@ fn nl_parse_idaes_helmholtz_fixture() {
     assert!(names.iter().any(|n| n == "h_liq_hp"), "expected h_liq_hp in {names:?}");
     assert!(names.iter().any(|n| n == "h_vap_hp"), "expected h_vap_hp in {names:?}");
 
-    let err = NlProblem::from_nl_data(data)
+    // Exercise the "no AMPLFUNC" path. Take the env lock so this doesn't
+    // race with nl_build_idaes_helmholtz_with_amplfunc, and clear AMPLFUNC
+    // for the duration of the call.
+    let _g = env_lock().lock().unwrap_or_else(|e| e.into_inner());
+    let prev = std::env::var_os("AMPLFUNC");
+    std::env::remove_var("AMPLFUNC");
+    let err_result = NlProblem::from_nl_data(data);
+    if let Some(v) = prev {
+        std::env::set_var("AMPLFUNC", v);
+    }
+
+    let err = err_result
         .err()
-        .expect("IDAES Helmholtz problem must be rejected at construction");
+        .expect("IDAES Helmholtz problem must be rejected when AMPLFUNC is unset");
     assert!(
         err.contains("external function"),
         "error should mention external functions, got: {err}"
     );
-    // The first Funcall encountered in the objective/constraints references
-    // one of the declared names.
     assert!(
         names.iter().any(|n| err.contains(n)),
         "error should name one of the imported functions, got: {err}"
     );
+}
+
+/// With `AMPLFUNC` pointing at the IDAES Helmholtz dylib, the IDAES fixture
+/// should actually build into an `NlProblem` — that means tape-level
+/// `Funcall` nodes were resolved against the loaded library. Skip when the
+/// dylib isn't installed locally; this isn't a ripopt bug.
+#[test]
+fn nl_build_idaes_helmholtz_with_amplfunc() {
+    let home = match std::env::var_os("HOME") {
+        Some(h) => std::path::PathBuf::from(h),
+        None => return,
+    };
+    let dylib = home.join(".idaes/bin/general_helmholtz_external.dylib");
+    if !dylib.exists() {
+        eprintln!("skipping: {} not installed", dylib.display());
+        return;
+    }
+
+    let nl = include_str!("fixtures/issue_15/idaes_helmholtz.nl");
+    let data = parse_nl_file(nl).expect("parse");
+
+    // Safety: env is process-global. This test stomps AMPLFUNC for its run;
+    // we restore it at the end so neighbouring tests aren't affected. Take the
+    // env lock so this doesn't race with nl_parse_idaes_helmholtz_fixture.
+    let _g = env_lock().lock().unwrap_or_else(|e| e.into_inner());
+    let prev = std::env::var_os("AMPLFUNC");
+    // SAFETY: `std::env::set_var` is only unsafe in the edition-2024 sense;
+    // in this crate's 2021 edition it's a stable safe function.
+    std::env::set_var("AMPLFUNC", dylib.as_os_str());
+    let result = NlProblem::from_nl_data(data);
+    match prev {
+        Some(v) => std::env::set_var("AMPLFUNC", v),
+        None => std::env::remove_var("AMPLFUNC"),
+    }
+
+    let _problem = result.expect("from_nl_data should succeed with AMPLFUNC set");
 }
 
 /// When the same `f<id>` token appears in a constraint, the error should


### PR DESCRIPTION
## Summary
- **Phase 1**: parse AMPL external-function segments (`F`, `f<id>`) and reject with a clear error naming the library and symbol.
- **Phase 2**: actually evaluate the external functions end-to-end via the `funcadd_ASL` ABI, so problems that call imported functions (IDAES Helmholtz property packages, etc.) solve instead of erroring.

## Phase 2 design
- `src/nl/external.rs` — dlopens AMPLFUNC libraries via `libloading`, registers functions through `funcadd_ASL` / `Addfunc`, evaluates with value / gradient / packed-upper-triangular Hessian. A process-wide `Mutex` guards load+call because AMPL libs keep mutable global state. Arity and string-arg type bits are validated per call.
- `src/nl/autodiff.rs` — new `TapeOp::Funcall` variant holding `Arc<ExternalLibrary>`. Every tape pass handles it: `forward`, `reverse` (chain rule through `derivs[k]`), `forward_tangent`, `hessian_accumulate` (forward-over-reverse with the packed Hessian), `hessian_sparsity` (self-product over real-arg vars), `remap_op`.
- `src/nl/problem_impl.rs` — `resolve_externals` walks the NL AST for funcall ids, loads each path on `AMPLFUNC` (colon- or newline-separated) as `Arc<ExternalLibrary>`, and maps referenced names to a library. Clean error if `AMPLFUNC` is unset or a required symbol is missing.
- `examples/probe_external.rs` — diagnostic that lists functions registered by a library.

## Result
```
AMPLFUNC=$HOME/.idaes/bin/general_helmholtz_external.dylib \
  cargo run --release --bin ripopt -- tests/fixtures/issue_15/idaes_helmholtz.nl
# → Optimal after 5 iterations. Objective: 0.000000000000000e0
```

## Test coverage

| Axis | Covered via |
|---|---|
| Parse funcall in objective / constraint | `nl_parse_external_function_*` |
| Load via `funcadd_ASL` | `load_idaes_helmholtz_dylib_registers_known_functions` |
| Clean error when `AMPLFUNC` unset | `nl_parse_idaes_helmholtz_fixture` |
| End-to-end IPM solve with externals | `nl_build_idaes_helmholtz_with_amplfunc` + CLI smoke |
| `type=1` (string args) + variadic `nargs<0` | `eval_vf_hp_*` against IDAES Helmholtz `vf_hp` |
| `type=0` (no strings) + exact `nargs>0` | `eval_cbrt_matches_closed_form` against IDAES `functions.dylib` |
| Closed-form value / deriv / Hessian check | `eval_cbrt_matches_closed_form` |
| Runtime arity mismatch rejection | `eval_cbrt_arity_mismatch_errors` |
| String arg to type=0 function rejected | `eval_cbrt_rejects_string_arg` |

## Known gaps — not exercised by any test

These paths are either not triggered by any AMPL library in our environment, or rely on optional AMPL ABI features we have not had a fixture for. The code may be wrong on these axes and we would not catch it:

- **`FUNCADD_OUTPUT_ARGS` (type bit 2)** — functions that return extra values through output slots instead of the return value. Our `eval()` accepts the type bit but does not wire the output path back to the caller. Likely broken if encountered.
- **`FUNCADD_RANDOM_VALUED` (type bit 4)** — RNG functions. Not handled at all; unusual in optimization NL files but possible.
- **Multiple libraries colon- or newline-separated in `AMPLFUNC`** — the splitter is implemented but no test exercises a model that needs symbols from two libraries at once.
- **Same symbol registered by two libraries** — our resolver is first-match-wins. Reasonable but untested.
- **Library-reported errors via `errmsg`** — we read the buffer and surface it as an `Err`, but no test triggers a library to write into it.
- **Variadic calls with many reals** (the IDAES fixture only hits `nargs=-4`, i.e. min 3). More extreme arities are not directly covered.

If you hit one of these in a real model, please open an issue with the library and `.nl` so we can add a fixture.

## Test plan
- [x] `cargo test` — 259/259 pass
- [x] `nl_parse_external_function_reports_clean_error` — rejection path still works when AMPLFUNC is absent
- [x] `nl_parse_idaes_helmholtz_fixture` — clean error when AMPLFUNC is unset (serialized via `env_lock()`)
- [x] `nl_build_idaes_helmholtz_with_amplfunc` — end-to-end build with AMPLFUNC set
- [x] `ripopt` CLI solves `tests/fixtures/issue_15/idaes_helmholtz.nl` to `Optimal`
- [x] Three new tests against `functions.dylib` cover `type=0`, exact arity, string-arg rejection

cc @CMarcher — phase 2 is ready. If you have a Helmholtz flowsheet `.nl` handy, you can solve it with:
```
AMPLFUNC=/path/to/library.dylib cargo run --release --bin ripopt -- yourmodel.nl
```
Multiple libraries work with colon- or newline-separated paths in `AMPLFUNC`.

Closes #15.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
